### PR TITLE
add basic install support for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,42 @@
 # AnonCreds: Anonymous credentials protocol implementation in python
 
-This is a python implementation of the anonymous credentials ideas
-developed by IBM Research (see https://idemix.wordpress.com/ and
-http://www.research.ibm.com/labs/zurich/idemix/). We have built
-some additional features for revocation.
+This is a python implementation of the anonymous credentials ideas developed by
+IBM Research (see https://idemix.wordpress.com/ and
+http://www.research.ibm.com/labs/zurich/idemix/). We have built some additional
+features for revocation.
 
-Anonymous Credentials requires a cryptographic framework. We have tested it with charm-crypto. 
-To install charm-crypto you just have to run `setup-charm.sh` script. It will require sudo privileges on the system.
+Anonymous Credentials requires a cryptographic framework. We have tested it
+with charm-crypto.  To install charm-crypto you just have to run
+`setup-charm.sh` script. It will require sudo privileges on the system.
+
+# Installation on Linux
+
+## Prerequisites for RedHat-based Systems
+
+- epel-release
+- python-setuptools
+- unzip
+- wget
+
+## Prerequisites for Debian-based Systems
+
+## Command-line Install
+
+```
+git clone https://github/evernym/anoncreds.git
+sh setupt-charm.sh
+```
 
 # Installation on Mac
 
-As a prerequisite first install http://brew.sh and OpenSLL https://solitum.net/openssl-os-x-el-capitan-and-brew
+## Prerequisites
 
-Then:
+- [Homebrew](http://brew.sh)
+- [OpenSSL](https://solitum.net/openssl-os-x-el-capitan-and-brew)
 
-`git clone https://github.com/evernym/anoncreds.git`
+## Command-line Install
 
-`sh setup-charm-homebrew.sh`
+```
+git clone https://github.com/evernym/anoncreds.git
+sh setup-charm-homebrew.sh
+```

--- a/setup-charm.sh
+++ b/setup-charm.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 set -e
 
-sudo apt-get install flex
-sudo apt-get install bison
-sudo apt-get install libssl-dev
-sudo apt-get install libgmp-dev
-sudo apt-get install python3-dev
+PKG_FLEX=flex
+PKG_BISON=bison
+
+if [ -f /etc/redhat-release ]
+then
+  PACKAGE_MANAGER=yum
+  PKG_SSL=openssl-devel
+  PKG_GMP=gmp-devel
+  PKG_PYTHON=python34-devel
+else
+  # assumes `apt-get` if not a RedHat-based system, which is
+  # probably not a good assumption.
+  PACKAGE_MANAGER=apt-get
+  PKG_SSL=libssl-dev
+  PKG_GMP=libgmp-dev
+  PKG_PYTHON=python3-dev
+fi
+
+sudo $PACKAGE_MANAGER -y install $PKG_FLEX
+sudo $PACKAGE_MANAGER -y install $PKG_BISON
+sudo $PACKAGE_MANAGER -y install $PKG_SSL
+sudo $PACKAGE_MANAGER -y install $PKG_GMP
+sudo $PACKAGE_MANAGER -y install $PKG_PYTHON
 
 # PBC
 # Cleanup any old data


### PR DESCRIPTION
The install script currently only supports Debian-based systems.
This commit extends installation support to CentOS. This is only
a partial solution, and will need to be refactored in order to
create a more general solution.