### PR TITLE
handle different package lists

### DIFF
--- a/setup-charm.sh
+++ b/setup-charm.sh
@@ -6,24 +6,24 @@ PKG_BISON=bison
 
 if [ -f /etc/redhat-release ]
 then
+  # assumes this is a RedHat-based system.
   PACKAGE_MANAGER=yum
   PKG_SSL=openssl-devel
   PKG_GMP=gmp-devel
-  PKG_PYTHON=python34-devel
 else
   # assumes `apt-get` if not a RedHat-based system, which is
   # probably not a good assumption.
   PACKAGE_MANAGER=apt-get
   PKG_SSL=libssl-dev
   PKG_GMP=libgmp-dev
-  PKG_PYTHON=python3-dev
+  PKG_PYTHON=pytddhon3-dev
 fi
 
-sudo $PACKAGE_MANAGER -y install $PKG_FLEX
-sudo $PACKAGE_MANAGER -y install $PKG_BISON
-sudo $PACKAGE_MANAGER -y install $PKG_SSL
-sudo $PACKAGE_MANAGER -y install $PKG_GMP
-sudo $PACKAGE_MANAGER -y install $PKG_PYTHON
+[[ ! -z $PKG_FLEX ]] && sudo $PACKAGE_MANAGER -y install $PKG_FLEX
+[[ ! -z $PKG_BISON ]] && sudo $PACKAGE_MANAGER -y install $PKG_BISON
+[[ ! -z $PKG_SSL ]] && sudo $PACKAGE_MANAGER -y install $PKG_SSL
+[[ ! -z $PKG_GMP ]] && sudo $PACKAGE_MANAGER -y install $PKG_GMP
+[[ ! -z $PKG_PYTHON ]] && sudo $PACKAGE_MANAGER -y install $PKG_PYTHON
 
 # PBC
 # Cleanup any old data

--- a/setup-charm.sh
+++ b/setup-charm.sh
@@ -16,7 +16,7 @@ else
   PACKAGE_MANAGER=apt-get
   PKG_SSL=libssl-dev
   PKG_GMP=libgmp-dev
-  PKG_PYTHON=pytddhon3-dev
+  PKG_PYTHON=python3-dev
 fi
 
 [[ ! -z $PKG_FLEX ]] && sudo $PACKAGE_MANAGER -y install $PKG_FLEX


### PR DESCRIPTION
RHEL 7-based systems do not have Python 3.5 as part of the default
installation, which is a requirement for this install script. In
order to get this package, one needs to install from SCL or from
source. Consequently, it isn't absolutely necessary (at least at this
point) to require the related `-devel` package in the install script.

This should be noted that this is really a stop-gap, and a more
robust solution is needed.