### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ dist/*/*
 # virtual environment
 include/
 
+# hidden files
+.*

--- a/GithubPR-Testdoc
+++ b/GithubPR-Testdoc
@@ -1,0 +1,1 @@
+This document is created to test the GithubPR integration with GoCD, once done with testing we will remove this document. 

--- a/anoncreds/protocol/primary/primary_proof_verifier.py
+++ b/anoncreds/protocol/primary/primary_proof_verifier.py
@@ -10,21 +10,21 @@ class PrimaryProofVerifier:
     def __init__(self, wallet: Wallet):
         self._wallet = wallet
 
-    async def verify(self, proofInput: ProofInput, claimDefKey, cHash,
+    async def verify(self, proofInput: ProofInput, schemaKey, cHash,
                      primaryProof: PrimaryProof, allRevealedAttrs):
         cH = cmod.integer(cHash)
-        THat = await self._verifyEquality(claimDefKey, cH, primaryProof.eqProof,
+        THat = await self._verifyEquality(schemaKey, cH, primaryProof.eqProof,
                                           allRevealedAttrs)
         for geProof in primaryProof.geProofs:
-            THat += await self._verifyGEPredicate(claimDefKey, cH, geProof)
+            THat += await self._verifyGEPredicate(schemaKey, cH, geProof)
 
         return THat
 
-    async def _verifyEquality(self, claimDefKey, cH, proof: PrimaryEqualProof,
+    async def _verifyEquality(self, schemaKey, cH, proof: PrimaryEqualProof,
                               allRevealedAttrs):
         THat = []
-        pk = await self._wallet.getPublicKey(ID(claimDefKey))
-        attrNames = (await self._wallet.getClaimDef(ID(claimDefKey))).attrNames
+        pk = await self._wallet.getPublicKey(ID(schemaKey))
+        attrNames = (await self._wallet.getSchema(ID(schemaKey))).attrNames
         unrevealedAttrNames = set(attrNames) - set(proof.revealedAttrNames)
 
         T1 = calcTeq(pk, proof.Aprime, proof.e, proof.v,
@@ -41,9 +41,9 @@ class PrimaryProofVerifier:
         THat.append(T)
         return THat
 
-    async def _verifyGEPredicate(self, claimDefKey, cH,
+    async def _verifyGEPredicate(self, schemaKey, cH,
                                  proof: PrimaryPredicateGEProof):
-        pk = await self._wallet.getPublicKey(ID(claimDefKey))
+        pk = await self._wallet.getPublicKey(ID(schemaKey))
         k, v = proof.predicate.attrName, proof.predicate.value
 
         TauList = calcTge(pk, proof.u, proof.r, proof.mj, proof.alpha, proof.T)

--- a/anoncreds/protocol/repo/attributes_repo.py
+++ b/anoncreds/protocol/repo/attributes_repo.py
@@ -1,15 +1,15 @@
 from abc import abstractmethod
 
-from anoncreds.protocol.types import Attribs, ClaimDefinitionKey
+from anoncreds.protocol.types import Attribs, SchemaKey
 
 
 class AttributeRepo:
     @abstractmethod
-    def getAttributes(self, claimDefKey: ClaimDefinitionKey, userId) -> Attribs:
+    def getAttributes(self, schemaKey: SchemaKey, userId) -> Attribs:
         raise NotImplementedError
 
     @abstractmethod
-    def addAttributes(self, claimDefKey: ClaimDefinitionKey, userId,
+    def addAttributes(self, schemaKey: SchemaKey, userId,
                       attributes: Attribs):
         raise NotImplementedError
 
@@ -18,9 +18,9 @@ class AttributeRepoInMemory(AttributeRepo):
     def __init__(self):
         self.attributes = {}
 
-    def getAttributes(self, claimDefKey: ClaimDefinitionKey, userId) -> Attribs:
-        return self.attributes.get((claimDefKey, userId))
+    def getAttributes(self, schemaKey: SchemaKey, userId) -> Attribs:
+        return self.attributes.get((schemaKey, userId))
 
-    def addAttributes(self, claimDefKey: ClaimDefinitionKey, userId,
+    def addAttributes(self, schemaKey: SchemaKey, userId,
                       attributes: Attribs):
-        self.attributes[(claimDefKey, userId)] = attributes
+        self.attributes[(schemaKey, userId)] = attributes

--- a/anoncreds/protocol/repo/public_repo.py
+++ b/anoncreds/protocol/repo/public_repo.py
@@ -2,162 +2,162 @@ from abc import abstractmethod
 from typing import Dict, Any
 
 from anoncreds.protocol.types import ID, PublicKey, RevocationPublicKey, \
-    ClaimDefinition, TailsType, Accumulator, \
-    AccumulatorPublicKey, TimestampType, ClaimDefinitionKey
+    Schema, TailsType, Accumulator, \
+    AccumulatorPublicKey, TimestampType, SchemaKey
 
 
 class PublicRepo:
     # GET
 
     @abstractmethod
-    async def getClaimDef(self, claimDefId: ID) -> ClaimDefinition:
+    async def getSchema(self, schemaId: ID) -> Schema:
         raise NotImplementedError
 
     @abstractmethod
-    async def getPublicKey(self, claimDefId: ID) -> PublicKey:
+    async def getPublicKey(self, schemaId: ID) -> PublicKey:
         raise NotImplementedError
 
     @abstractmethod
     async def getPublicKeyRevocation(self,
-                                     claimDefId: ID) -> RevocationPublicKey:
+                                     schemaId: ID) -> RevocationPublicKey:
         raise NotImplementedError
 
     @abstractmethod
     async def getPublicKeyAccumulator(self,
-                                      claimDefId: ID) -> AccumulatorPublicKey:
+                                      schemaId: ID) -> AccumulatorPublicKey:
         raise NotImplementedError
 
     @abstractmethod
-    async def getAccumulator(self, claimDefId: ID) -> Accumulator:
+    async def getAccumulator(self, schemaId: ID) -> Accumulator:
         raise NotImplementedError
 
     @abstractmethod
-    async def getTails(self, claimDefId: ID) -> TailsType:
+    async def getTails(self, schemaId: ID) -> TailsType:
         raise NotImplementedError
 
     # SUBMIT
 
     @abstractmethod
-    async def submitClaimDef(self,
-                             claimDef: ClaimDefinition) -> ClaimDefinition:
+    async def submitSchema(self,
+                           schema: Schema) -> Schema:
         raise NotImplementedError
 
     @abstractmethod
-    async def submitPublicKeys(self, claimDefId: ID, pk: PublicKey,
+    async def submitPublicKeys(self, schemaId: ID, pk: PublicKey,
                                pkR: RevocationPublicKey = None) -> (
             PublicKey, RevocationPublicKey):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitAccumulator(self, claimDefId: ID,
+    async def submitAccumulator(self, schemaId: ID,
                                 accumPK: AccumulatorPublicKey,
                                 accum: Accumulator, tails: TailsType) -> \
             AccumulatorPublicKey:
         raise NotImplementedError
 
     @abstractmethod
-    async def submitAccumUpdate(self, claimDefId: ID, accum: Accumulator,
+    async def submitAccumUpdate(self, schemaId: ID, accum: Accumulator,
                                 timestampMs: TimestampType):
         raise NotImplementedError
 
 
 class PublicRepoInMemory(PublicRepo):
     def __init__(self):
-        self._claimDefsByKey = {}
-        self._claimDefsById = {}
+        self._schemasByKey = {}
+        self._schemasById = {}
         self._pks = {}
         self._pkRs = {}
         self._accums = {}
         self._accumPks = {}
         self._tails = {}
-        self._claimDefId = 1
+        self._schemaId = 1
         self._pkId = 1
         self._pkRId = 1
         self._acumPkId = 1
 
     # GET
 
-    async def getClaimDef(self, claimDefId: ID) -> ClaimDefinition:
-        if claimDefId.claimDefKey and claimDefId.claimDefKey in self._claimDefsByKey:
-            return self._claimDefsByKey[claimDefId.claimDefKey]
+    async def getSchema(self, schemaId: ID) -> Schema:
+        if schemaId.schemaKey and schemaId.schemaKey in self._schemasByKey:
+            return self._schemasByKey[schemaId.schemaKey]
 
-        if claimDefId.claimDefId and claimDefId.claimDefId in self._claimDefsById:
-            return self._claimDefsById[claimDefId.claimDefId]
+        if schemaId.schemaId and schemaId.schemaId in self._schemasById:
+            return self._schemasById[schemaId.schemaId]
 
         raise KeyError(
-            'No claim definition with ID={} and key={}'.format(
-                claimDefId.claimDefId,
-                claimDefId.claimDefKey))
+            'No schema with ID={} and key={}'.format(
+                schemaId.schemaId,
+                schemaId.schemaKey))
 
-    async def getPublicKey(self, claimDefId: ID) -> PublicKey:
-        return await self._getValueForId(self._pks, claimDefId)
+    async def getPublicKey(self, schemaId: ID) -> PublicKey:
+        return await self._getValueForId(self._pks, schemaId)
 
     async def getPublicKeyRevocation(self,
-                                     claimDefId: ID) -> RevocationPublicKey:
-        return await self._getValueForId(self._pkRs, claimDefId)
+                                     schemaId: ID) -> RevocationPublicKey:
+        return await self._getValueForId(self._pkRs, schemaId)
 
     async def getPublicKeyAccumulator(self,
-                                      claimDefId: ID) -> AccumulatorPublicKey:
-        return await self._getValueForId(self._accumPks, claimDefId)
+                                      schemaId: ID) -> AccumulatorPublicKey:
+        return await self._getValueForId(self._accumPks, schemaId)
 
-    async def getAccumulator(self, claimDefId: ID) -> Accumulator:
-        return await self._getValueForId(self._accums, claimDefId)
+    async def getAccumulator(self, schemaId: ID) -> Accumulator:
+        return await self._getValueForId(self._accums, schemaId)
 
-    async def getTails(self, claimDefId: ID) -> TailsType:
-        return await self._getValueForId(self._tails, claimDefId)
+    async def getTails(self, schemaId: ID) -> TailsType:
+        return await self._getValueForId(self._tails, schemaId)
 
     # SUBMIT
 
-    async def submitClaimDef(self,
-                             claimDef: ClaimDefinition) -> ClaimDefinition:
-        claimDef = claimDef._replace(seqId=self._claimDefId)
-        self._claimDefId += 1
-        self._claimDefsByKey[claimDef.getKey()] = claimDef
-        self._claimDefsById[claimDef.seqId] = claimDef
-        return claimDef
+    async def submitSchema(self,
+                           schema: Schema) -> Schema:
+        schema = schema._replace(seqId=self._schemaId)
+        self._schemaId += 1
+        self._schemasByKey[schema.getKey()] = schema
+        self._schemasById[schema.seqId] = schema
+        return schema
 
-    async def submitPublicKeys(self, claimDefId: ID, pk: PublicKey,
+    async def submitPublicKeys(self, schemaId: ID, pk: PublicKey,
                                pkR: RevocationPublicKey = None) -> (
             PublicKey, RevocationPublicKey):
         pk = pk._replace(seqId=self._pkId)
         self._pkId += 1
-        await self._cacheValueForId(self._pks, claimDefId, pk)
+        await self._cacheValueForId(self._pks, schemaId, pk)
 
         if pkR:
             pkR = pkR._replace(seqId=self._pkRId)
             self._pkRId += 1
-            await self._cacheValueForId(self._pkRs, claimDefId, pkR)
+            await self._cacheValueForId(self._pkRs, schemaId, pkR)
 
         return pk, pkR
 
-    async def submitAccumulator(self, claimDefId: ID,
+    async def submitAccumulator(self, schemaId: ID,
                                 accumPK: AccumulatorPublicKey,
                                 accum: Accumulator,
                                 tails: TailsType) -> AccumulatorPublicKey:
         accumPK = accumPK._replace(seqId=self._acumPkId)
         self._acumPkId += 1
-        await self._cacheValueForId(self._accums, claimDefId, accum)
-        accumPk = await self._cacheValueForId(self._accumPks, claimDefId,
+        await self._cacheValueForId(self._accums, schemaId, accum)
+        accumPk = await self._cacheValueForId(self._accumPks, schemaId,
                                               accumPK)
-        await self._cacheValueForId(self._tails, claimDefId, tails)
+        await self._cacheValueForId(self._tails, schemaId, tails)
         return accumPk
 
-    async def submitAccumUpdate(self, claimDefId: ID, accum: Accumulator,
+    async def submitAccumUpdate(self, schemaId: ID, accum: Accumulator,
                                 timestampMs: TimestampType):
-        await self._cacheValueForId(self._accums, claimDefId, accum)
+        await self._cacheValueForId(self._accums, schemaId, accum)
 
-    async def _getValueForId(self, dictionary: Dict[ClaimDefinitionKey, Any],
-                             claimDefId: ID) -> Any:
-        claimDef = await self.getClaimDef(claimDefId)
-        claimDefKey = claimDef.getKey()
-        if not claimDefKey in dictionary:
+    async def _getValueForId(self, dictionary: Dict[SchemaKey, Any],
+                             schemaId: ID) -> Any:
+        schema = await self.getSchema(schemaId)
+        schemaKey = schema.getKey()
+        if not schemaKey in dictionary:
             raise ValueError(
-                'No value for claim definition with ID={} and key={}'.format(
-                    id.claimDefId, id.claimDefKey))
-        return dictionary[claimDefKey]
+                'No value for schema with ID={} and key={}'.format(
+                    schemaId.schemaId, schemaId.schemaKey))
+        return dictionary[schemaKey]
 
-    async def _cacheValueForId(self, dictionary: Dict[ClaimDefinitionKey, Any],
-                               claimDefId: ID, value: Any):
-        claimDef = await self.getClaimDef(claimDefId)
-        claimDefKey = claimDef.getKey()
-        dictionary[claimDefKey] = value
+    async def _cacheValueForId(self, dictionary: Dict[SchemaKey, Any],
+                               schemaId: ID, value: Any):
+        schema = await self.getSchema(schemaId)
+        schemaKey = schema.getKey()
+        dictionary[schemaKey] = value

--- a/anoncreds/protocol/revocation/accumulators/non_revocation_claim_issuer.py
+++ b/anoncreds/protocol/revocation/accumulators/non_revocation_claim_issuer.py
@@ -36,11 +36,11 @@ class NonRevocationClaimIssuer:
         return (RevocationPublicKey(qr, g, h, h0, h1, h2, htilde, u, pk, y, x),
                 RevocationSecretKey(x, sk))
 
-    async def issueAccumulator(self, claimDefId, iA, L) \
+    async def issueAccumulator(self, schemaId, iA, L) \
             -> (
                     Accumulator, TailsType, AccumulatorPublicKey,
                     AccumulatorSecretKey):
-        pkR = await self._wallet.getPublicKeyRevocation(claimDefId)
+        pkR = await self._wallet.getPublicKeyRevocation(schemaId)
         group = cmod.PairingGroup(PAIRING_GROUP)
         gamma = group.random(cmod.ZR)
 
@@ -59,14 +59,14 @@ class NonRevocationClaimIssuer:
         accum = Accumulator(iA, acc, V, L)
         return accum, g, accPK, accSK
 
-    async def issueNonRevocationClaim(self, claimDefId: ID, Ur, iA, i) -> (
+    async def issueNonRevocationClaim(self, schemaId: ID, Ur, iA, i) -> (
             NonRevocationClaim, Accumulator, TimestampType):
-        accum = await self._wallet.getAccumulator(claimDefId)
-        pkR = await self._wallet.getPublicKeyRevocation(claimDefId)
-        skR = await self._wallet.getSecretKeyRevocation(claimDefId)
-        g = await self._wallet.getTails(claimDefId)
-        skAccum = await self._wallet.getSecretKeyAccumulator(claimDefId)
-        m2 = await self._wallet.getContextAttr(claimDefId)
+        accum = await self._wallet.getAccumulator(schemaId)
+        pkR = await self._wallet.getPublicKeyRevocation(schemaId)
+        skR = await self._wallet.getSecretKeyRevocation(schemaId)
+        g = await self._wallet.getTails(schemaId)
+        skAccum = await self._wallet.getSecretKeyAccumulator(schemaId)
+        m2 = await self._wallet.getContextAttr(schemaId)
 
         if accum.isFull():
             raise ValueError("Accumulator is full. New one must be issued.")
@@ -101,9 +101,9 @@ class NonRevocationClaimIssuer:
                                i,
                                m2), accum, ts)
 
-    async def revoke(self, claimDefId: ID, i) -> (Accumulator, TimestampType):
-        accum = await self._wallet.getAccumulator(claimDefId)
-        tails = await self._wallet.getTails(claimDefId)
+    async def revoke(self, schemaId: ID, i) -> (Accumulator, TimestampType):
+        accum = await self._wallet.getAccumulator(schemaId)
+        tails = await self._wallet.getTails(schemaId)
 
         accum.V.discard(i)
         accum.acc /= tails[accum.L + 1 - i]

--- a/anoncreds/protocol/revocation/accumulators/non_revocation_proof_verifier.py
+++ b/anoncreds/protocol/revocation/accumulators/non_revocation_proof_verifier.py
@@ -14,20 +14,20 @@ class NonRevocationProofVerifier:
     def __init__(self, wallet: Wallet):
         self._wallet = wallet
 
-    async def verifyNonRevocation(self, proofInput: ProofInput, claimDefKey,
+    async def verifyNonRevocation(self, proofInput: ProofInput, schemaKey,
                                   cHash, nonRevocProof: NonRevocProof) \
             -> Sequence[T]:
         if await self._wallet.shouldUpdateAccumulator(
-                claimDefId=ID(claimDefKey),
+                schemaId=ID(schemaKey),
                 ts=proofInput.ts,
                 seqNo=proofInput.seqNo):
-            await self._wallet.updateAccumulator(claimDefId=ID(claimDefKey),
+            await self._wallet.updateAccumulator(schemaId=ID(schemaKey),
                                                  ts=proofInput.ts,
                                                  seqNo=proofInput.seqNo)
 
-        pkR = await self._wallet.getPublicKeyRevocation(ID(claimDefKey))
-        accum = await self._wallet.getAccumulator(ID(claimDefKey))
-        accumPk = await self._wallet.getPublicKeyAccumulator(ID(claimDefKey))
+        pkR = await self._wallet.getPublicKeyRevocation(ID(schemaKey))
+        accum = await self._wallet.getAccumulator(ID(schemaKey))
+        accumPk = await self._wallet.getPublicKeyAccumulator(ID(schemaKey))
 
         CProof = nonRevocProof.CProof
         XList = nonRevocProof.XList

--- a/anoncreds/protocol/types.py
+++ b/anoncreds/protocol/types.py
@@ -145,31 +145,31 @@ class StrSerializer:
         return cls(**d)
 
 
-class ClaimDefinitionKey(
-    namedtuple('ClaimDefinitionKey', 'name, version, issuerId'),
+class SchemaKey(
+    namedtuple('SchemaKey', 'name, version, issuerId'),
     NamedTupleStrSerializer):
     def __hash__(self):
         keys = (self.name, self.version, self.issuerId)
         return hash(keys)
 
 
-class ID(namedtuple('ID', 'claimDefKey, claimDefId, seqId')):
-    def __new__(cls, claimDefKey: ClaimDefinitionKey = None, claimDefId=None,
+class ID(namedtuple('ID', 'schemaKey, schemaId, seqId')):
+    def __new__(cls, schemaKey: SchemaKey = None, schemaId=None,
                 seqId=None):
-        return super(ID, cls).__new__(cls, claimDefKey, claimDefId, seqId)
+        return super(ID, cls).__new__(cls, schemaKey, schemaId, seqId)
 
 
-class ClaimDefinition(namedtuple('CredentialDefinition',
-                                 'name, version, attrNames, claimDefType, '
-                                 'issuerId, seqId'),
-                      NamedTupleStrSerializer):
-    def __new__(cls, name, version, attrNames, claimDefType, issuerId, seqId=None):
-        return super(ClaimDefinition, cls).__new__(cls, name, version,
-                                                   attrNames, claimDefType, issuerId,
-                                                   seqId)
+class Schema(namedtuple('Schema',
+                        'name, version, attrNames, schemaType, '
+                        'issuerId, seqId'),
+             NamedTupleStrSerializer):
+    def __new__(cls, name, version, attrNames, schemaType, issuerId, seqId=None):
+        return super(Schema, cls).__new__(cls, name, version,
+                                          attrNames, schemaType, issuerId,
+                                          seqId)
 
     def getKey(self):
-        return ClaimDefinitionKey(self.name, self.version, self.issuerId)
+        return SchemaKey(self.name, self.version, self.issuerId)
 
 
 class PublicKey(namedtuple('PublicKey', 'N, Rms, Rctxt, R, S, Z, seqId'),
@@ -481,7 +481,7 @@ class Proof(namedtuple('Proof', 'primaryProof, nonRevocProof'),
         return Proof(primaryProof=primaryProof, nonRevocProof=nonRevocProof)
 
 
-class FullProof(namedtuple('FullProof', 'cHash, claimDefKeys, proofs, CList'),
+class FullProof(namedtuple('FullProof', 'cHash, schemaKeys, proofs, CList'),
                 NamedTupleStrSerializer):
     def getCredDefs(self):
         return self.proofs.keys()
@@ -489,9 +489,9 @@ class FullProof(namedtuple('FullProof', 'cHash, claimDefKeys, proofs, CList'),
     @classmethod
     def fromStrDict(cls, d):
         cHash = deserializeFromStr(d['cHash'])
-        claimDefKeys = [ClaimDefinitionKey.fromStrDict(v) for v in
-                        d['claimDefKeys']]
+        schemaKeys = [SchemaKey.fromStrDict(v) for v in
+                      d['schemaKeys']]
         proofs = [Proof.fromStrDict(v) for v in d['proofs']]
         CList = [deserializeFromStr(v) for v in d['CList']]
-        return FullProof(cHash=cHash, claimDefKeys=claimDefKeys, proofs=proofs,
+        return FullProof(cHash=cHash, schemaKeys=schemaKeys, proofs=proofs,
                          CList=CList)

--- a/anoncreds/protocol/verifier.py
+++ b/anoncreds/protocol/verifier.py
@@ -37,14 +37,14 @@ class Verifier:
         :return: True if verified successfully and false otherwise.
         """
         TauList = []
-        for claimDefKey, proofItem in zip(proof.claimDefKeys, proof.proofs):
+        for schemaKey, proofItem in zip(proof.schemaKeys, proof.proofs):
             if proofItem.nonRevocProof:
                 TauList += await self._nonRevocVerifier.verifyNonRevocation(
-                    proofInput, claimDefKey, proof.cHash,
+                    proofInput, schemaKey, proof.cHash,
                     proofItem.nonRevocProof)
             if proofItem.primaryProof:
                 TauList += await self._primaryVerifier.verify(proofInput,
-                                                              claimDefKey,
+                                                              schemaKey,
                                                               proof.cHash,
                                                               proofItem.primaryProof,
                                                               allRevealedAttrs)

--- a/anoncreds/protocol/wallet/issuer_wallet.py
+++ b/anoncreds/protocol/wallet/issuer_wallet.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 
 from anoncreds.protocol.repo.public_repo import PublicRepo
-from anoncreds.protocol.types import ClaimDefinition, PublicKey, SecretKey, ID, \
+from anoncreds.protocol.types import Schema, PublicKey, SecretKey, ID, \
     RevocationPublicKey, AccumulatorPublicKey, Accumulator, TailsType, \
     RevocationSecretKey, AccumulatorSecretKey, \
     TimestampType
@@ -9,73 +9,73 @@ from anoncreds.protocol.wallet.wallet import Wallet, WalletInMemory
 
 
 class IssuerWallet(Wallet):
-    def __init__(self, claimDefId, repo: PublicRepo):
-        Wallet.__init__(self, claimDefId, repo)
+    def __init__(self, schemaId, repo: PublicRepo):
+        Wallet.__init__(self, schemaId, repo)
 
     # SUBMIT
 
     @abstractmethod
-    async def submitClaimDef(self,
-                             claimDef: ClaimDefinition) -> ClaimDefinition:
+    async def submitSchema(self,
+                           schema: Schema) -> Schema:
         raise NotImplementedError
 
     @abstractmethod
-    async def submitPublicKeys(self, claimDefId: ID, pk: PublicKey,
+    async def submitPublicKeys(self, schemaId: ID, pk: PublicKey,
                                pkR: RevocationPublicKey = None) -> (
             PublicKey, RevocationPublicKey):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitSecretKeys(self, claimDefId: ID, sk: SecretKey,
+    async def submitSecretKeys(self, schemaId: ID, sk: SecretKey,
                                skR: RevocationSecretKey = None):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitAccumPublic(self, claimDefId: ID,
+    async def submitAccumPublic(self, schemaId: ID,
                                 accumPK: AccumulatorPublicKey,
                                 accum: Accumulator, tails: TailsType):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitAccumSecret(self, claimDefId: ID,
+    async def submitAccumSecret(self, schemaId: ID,
                                 accumSK: AccumulatorSecretKey):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitAccumUpdate(self, claimDefId: ID, accum: Accumulator,
+    async def submitAccumUpdate(self, schemaId: ID, accum: Accumulator,
                                 timestampMs: TimestampType):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitContextAttr(self, claimDefId: ID, m2):
+    async def submitContextAttr(self, schemaId: ID, m2):
         raise NotImplementedError
 
     # GET
 
     @abstractmethod
-    async def getSecretKey(self, claimDefId: ID) -> SecretKey:
+    async def getSecretKey(self, schemaId: ID) -> SecretKey:
         raise NotImplementedError
 
     @abstractmethod
     async def getSecretKeyRevocation(self,
-                                     claimDefId: ID) -> RevocationSecretKey:
+                                     schemaId: ID) -> RevocationSecretKey:
         raise NotImplementedError
 
     @abstractmethod
     async def getSecretKeyAccumulator(self,
-                                      claimDefId: ID) -> AccumulatorSecretKey:
+                                      schemaId: ID) -> AccumulatorSecretKey:
         raise NotImplementedError
 
     @abstractmethod
-    async def getContextAttr(self, claimDefId: ID):
+    async def getContextAttr(self, schemaId: ID):
         raise NotImplementedError
 
 
 class IssuerWalletInMemory(IssuerWallet, WalletInMemory):
-    def __init__(self, claimDefId, repo: PublicRepo):
-        WalletInMemory.__init__(self, claimDefId, repo)
+    def __init__(self, schemaId, repo: PublicRepo):
+        WalletInMemory.__init__(self, schemaId, repo)
 
-        # other dicts with key=claimDefKey
+        # other dicts with key=schemaKey
         self._sks = {}
         self._skRs = {}
         self._accumSks = {}
@@ -84,62 +84,62 @@ class IssuerWalletInMemory(IssuerWallet, WalletInMemory):
 
     # SUBMIT
 
-    async def submitClaimDef(self,
-                             claimDef: ClaimDefinition) -> ClaimDefinition:
-        claimDef = await self._repo.submitClaimDef(claimDef)
-        self._cacheClaimDef(claimDef)
-        return claimDef
+    async def submitSchema(self,
+                           schema: Schema) -> Schema:
+        schema = await self._repo.submitSchema(schema)
+        self._cacheSchema(schema)
+        return schema
 
-    async def submitPublicKeys(self, claimDefId: ID, pk: PublicKey,
+    async def submitPublicKeys(self, schemaId: ID, pk: PublicKey,
                                pkR: RevocationPublicKey = None) -> (
             PublicKey, RevocationPublicKey):
-        pk, pkR = await self._repo.submitPublicKeys(claimDefId, pk, pkR)
-        await self._cacheValueForId(self._pks, claimDefId, pk)
+        pk, pkR = await self._repo.submitPublicKeys(schemaId, pk, pkR)
+        await self._cacheValueForId(self._pks, schemaId, pk)
         if pkR:
-            await  self._cacheValueForId(self._pkRs, claimDefId, pkR)
+            await  self._cacheValueForId(self._pkRs, schemaId, pkR)
         return pk, pkR
 
-    async def submitSecretKeys(self, claimDefId: ID, sk: SecretKey,
+    async def submitSecretKeys(self, schemaId: ID, sk: SecretKey,
                                skR: RevocationSecretKey = None):
-        await  self._cacheValueForId(self._sks, claimDefId, sk)
+        await  self._cacheValueForId(self._sks, schemaId, sk)
         if skR:
-            await  self._cacheValueForId(self._skRs, claimDefId, skR)
+            await  self._cacheValueForId(self._skRs, schemaId, skR)
 
-    async def submitAccumPublic(self, claimDefId: ID,
+    async def submitAccumPublic(self, schemaId: ID,
                                 accumPK: AccumulatorPublicKey,
                                 accum: Accumulator,
                                 tails: TailsType) -> AccumulatorPublicKey:
-        accumPK = await self._repo.submitAccumulator(claimDefId, accumPK, accum,
+        accumPK = await self._repo.submitAccumulator(schemaId, accumPK, accum,
                                                      tails)
-        await self._cacheValueForId(self._accums, claimDefId, accum)
-        await self._cacheValueForId(self._accumPks, claimDefId, accumPK)
-        await self._cacheValueForId(self._tails, claimDefId, tails)
+        await self._cacheValueForId(self._accums, schemaId, accum)
+        await self._cacheValueForId(self._accumPks, schemaId, accumPK)
+        await self._cacheValueForId(self._tails, schemaId, tails)
         return accumPK
 
-    async def submitAccumSecret(self, claimDefId: ID,
+    async def submitAccumSecret(self, schemaId: ID,
                                 accumSK: AccumulatorSecretKey):
-        await self._cacheValueForId(self._accumSks, claimDefId, accumSK)
+        await self._cacheValueForId(self._accumSks, schemaId, accumSK)
 
-    async def submitAccumUpdate(self, claimDefId: ID, accum: Accumulator,
+    async def submitAccumUpdate(self, schemaId: ID, accum: Accumulator,
                                 timestampMs: TimestampType):
-        await self._repo.submitAccumUpdate(claimDefId, accum, timestampMs)
-        await self._cacheValueForId(self._accums, claimDefId, accum)
+        await self._repo.submitAccumUpdate(schemaId, accum, timestampMs)
+        await self._cacheValueForId(self._accums, schemaId, accum)
 
-    async def submitContextAttr(self, claimDefId: ID, m2):
-        await self._cacheValueForId(self._m2s, claimDefId, m2)
+    async def submitContextAttr(self, schemaId: ID, m2):
+        await self._cacheValueForId(self._m2s, schemaId, m2)
 
     # GET
 
-    async def getSecretKey(self, claimDefId: ID) -> SecretKey:
-        return await self._getValueForId(self._sks, claimDefId)
+    async def getSecretKey(self, schemaId: ID) -> SecretKey:
+        return await self._getValueForId(self._sks, schemaId)
 
     async def getSecretKeyRevocation(self,
-                                     claimDefId: ID) -> RevocationSecretKey:
-        return await self._getValueForId(self._skRs, claimDefId)
+                                     schemaId: ID) -> RevocationSecretKey:
+        return await self._getValueForId(self._skRs, schemaId)
 
     async def getSecretKeyAccumulator(self,
-                                      claimDefId: ID) -> AccumulatorSecretKey:
-        return await self._getValueForId(self._accumSks, claimDefId)
+                                      schemaId: ID) -> AccumulatorSecretKey:
+        return await self._getValueForId(self._accumSks, schemaId)
 
-    async def getContextAttr(self, claimDefId: ID):
-        return await self._getValueForId(self._m2s, claimDefId)
+    async def getContextAttr(self, schemaId: ID):
+        return await self._getValueForId(self._m2s, schemaId)

--- a/anoncreds/protocol/wallet/prover_wallet.py
+++ b/anoncreds/protocol/wallet/prover_wallet.py
@@ -2,79 +2,79 @@ from abc import abstractmethod
 from typing import Dict
 
 from anoncreds.protocol.repo.public_repo import PublicRepo
-from anoncreds.protocol.types import ClaimDefinitionKey, ID, \
+from anoncreds.protocol.types import SchemaKey, ID, \
     Claims, ClaimInitDataType, \
     PrimaryClaim, NonRevocationClaim
 from anoncreds.protocol.wallet.wallet import Wallet, WalletInMemory
 
 
 class ProverWallet(Wallet):
-    def __init__(self, claimDefId, repo: PublicRepo):
-        Wallet.__init__(self, claimDefId, repo)
+    def __init__(self, schemaId, repo: PublicRepo):
+        Wallet.__init__(self, schemaId, repo)
 
     # SUBMIT
 
     @abstractmethod
-    async def submitPrimaryClaim(self, claimDefId: ID, claim: PrimaryClaim):
+    async def submitPrimaryClaim(self, schemaId: ID, claim: PrimaryClaim):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitNonRevocClaim(self, claimDefId: ID,
+    async def submitNonRevocClaim(self, schemaId: ID,
                                   claim: NonRevocationClaim):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitMasterSecret(self, ms, claimDefId: ID):
+    async def submitMasterSecret(self, ms, schemaId: ID):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitPrimaryClaimInitData(self, claimDefId: ID,
+    async def submitPrimaryClaimInitData(self, schemaId: ID,
                                          claimInitData: ClaimInitDataType):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitNonRevocClaimInitData(self, claimDefId: ID,
+    async def submitNonRevocClaimInitData(self, schemaId: ID,
                                           claimInitData: ClaimInitDataType):
         raise NotImplementedError
 
     @abstractmethod
-    async def submitContextAttr(self, claimDefId: ID, m2):
+    async def submitContextAttr(self, schemaId: ID, m2):
         raise NotImplementedError
 
     # GET
 
     @abstractmethod
-    async def getMasterSecret(self, claimDefId: ID):
+    async def getMasterSecret(self, schemaId: ID):
         raise NotImplementedError
 
     @abstractmethod
-    async def getClaims(self, claimDefId: ID) -> Claims:
+    async def getClaims(self, schemaId: ID) -> Claims:
         raise NotImplementedError
 
     @abstractmethod
-    async def getAllClaims(self) -> Dict[ClaimDefinitionKey, Claims]:
+    async def getAllClaims(self) -> Dict[SchemaKey, Claims]:
         raise NotImplementedError
 
     @abstractmethod
     async def getPrimaryClaimInitData(self,
-                                      claimDefId: ID) -> ClaimInitDataType:
+                                      schemaId: ID) -> ClaimInitDataType:
         raise NotImplementedError
 
     @abstractmethod
     async def getNonRevocClaimInitData(self,
-                                       claimDefId: ID) -> ClaimInitDataType:
+                                       schemaId: ID) -> ClaimInitDataType:
         raise NotImplementedError
 
     @abstractmethod
-    async def getContextAttr(self, claimDefId: ID):
+    async def getContextAttr(self, schemaId: ID):
         raise NotImplementedError
 
 
 class ProverWalletInMemory(ProverWallet, WalletInMemory):
-    def __init__(self, claimDefId, repo: PublicRepo):
-        WalletInMemory.__init__(self, claimDefId, repo)
+    def __init__(self, schemaId, repo: PublicRepo):
+        WalletInMemory.__init__(self, schemaId, repo)
 
-        # other dicts with key=claimDefKey
+        # other dicts with key=schemaKey
         self._m1s = {}
         self._m2s = {}
 
@@ -86,53 +86,53 @@ class ProverWalletInMemory(ProverWallet, WalletInMemory):
 
     # SUBMIT
 
-    async def submitPrimaryClaim(self, claimDefId: ID, claim: PrimaryClaim):
-        await self._cacheValueForId(self._c1s, claimDefId, claim)
+    async def submitPrimaryClaim(self, schemaId: ID, claim: PrimaryClaim):
+        await self._cacheValueForId(self._c1s, schemaId, claim)
 
-    async def submitNonRevocClaim(self, claimDefId: ID,
+    async def submitNonRevocClaim(self, schemaId: ID,
                                   claim: NonRevocationClaim):
-        await self._cacheValueForId(self._c2s, claimDefId, claim)
+        await self._cacheValueForId(self._c2s, schemaId, claim)
 
-    async def submitMasterSecret(self, ms, claimDefId: ID):
-        await self._cacheValueForId(self._m1s, claimDefId, ms)
+    async def submitMasterSecret(self, ms, schemaId: ID):
+        await self._cacheValueForId(self._m1s, schemaId, ms)
 
-    async def submitPrimaryClaimInitData(self, claimDefId: ID,
+    async def submitPrimaryClaimInitData(self, schemaId: ID,
                                          claimInitData: ClaimInitDataType):
-        await self._cacheValueForId(self._primaryInitData, claimDefId,
+        await self._cacheValueForId(self._primaryInitData, schemaId,
                                     claimInitData)
 
-    async def submitNonRevocClaimInitData(self, claimDefId: ID,
+    async def submitNonRevocClaimInitData(self, schemaId: ID,
                                           claimInitData: ClaimInitDataType):
-        await self._cacheValueForId(self._nonRevocInitData, claimDefId,
+        await self._cacheValueForId(self._nonRevocInitData, schemaId,
                                     claimInitData)
 
-    async def submitContextAttr(self, claimDefId: ID, m2):
-        await self._cacheValueForId(self._m2s, claimDefId, m2)
+    async def submitContextAttr(self, schemaId: ID, m2):
+        await self._cacheValueForId(self._m2s, schemaId, m2)
 
     # GET
 
-    async def getMasterSecret(self, claimDefId: ID):
-        return await self._getValueForId(self._m1s, claimDefId)
+    async def getMasterSecret(self, schemaId: ID):
+        return await self._getValueForId(self._m1s, schemaId)
 
-    async def getClaims(self, claimDefId: ID) -> Claims:
-        c1 = await self._getValueForId(self._c1s, claimDefId)
+    async def getClaims(self, schemaId: ID) -> Claims:
+        c1 = await self._getValueForId(self._c1s, schemaId)
         c2 = None if not self._c2s else await self._getValueForId(self._c2s,
-                                                                  claimDefId)
+                                                                  schemaId)
         return Claims(c1, c2)
 
-    async def getAllClaims(self) -> Dict[ClaimDefinitionKey, Claims]:
+    async def getAllClaims(self) -> Dict[SchemaKey, Claims]:
         res = {}
-        for claimDefKey in self._c1s.keys():
-            res[claimDefKey] = await self.getClaims(ID(claimDefKey))
+        for schemaKey in self._c1s.keys():
+            res[schemaKey] = await self.getClaims(ID(schemaKey))
         return res
 
     async def getPrimaryClaimInitData(self,
-                                      claimDefId: ID) -> ClaimInitDataType:
-        return await self._getValueForId(self._primaryInitData, claimDefId)
+                                      schemaId: ID) -> ClaimInitDataType:
+        return await self._getValueForId(self._primaryInitData, schemaId)
 
     async def getNonRevocClaimInitData(self,
-                                       claimDefId: ID) -> ClaimInitDataType:
-        return await self._getValueForId(self._nonRevocInitData, claimDefId)
+                                       schemaId: ID) -> ClaimInitDataType:
+        return await self._getValueForId(self._nonRevocInitData, schemaId)
 
-    async def getContextAttr(self, claimDefId: ID):
-        return await self._getValueForId(self._m2s, claimDefId)
+    async def getContextAttr(self, schemaId: ID):
+        return await self._getValueForId(self._m2s, schemaId)

--- a/anoncreds/test/conftest.py
+++ b/anoncreds/test/conftest.py
@@ -122,130 +122,130 @@ def verifier(publicRepo):
 
 
 @pytest.fixture(scope="function")
-def claimDefGvt(issuerGvt, event_loop):
+def schemaGvt(issuerGvt, event_loop):
     return event_loop.run_until_complete(
-        issuerGvt.genClaimDef("GVT", "1.0", GVT.attribNames()))
+        issuerGvt.genSchema("GVT", "1.0", GVT.attribNames()))
 
 
 @pytest.fixture(scope="function")
-def claimDefXyz(issuerXyz, event_loop):
+def schemaXyz(issuerXyz, event_loop):
     return event_loop.run_until_complete(
-        issuerXyz.genClaimDef("XYZCorp", "1.0", XYZCorp.attribNames()))
+        issuerXyz.genSchema("XYZCorp", "1.0", XYZCorp.attribNames()))
 
 
 @pytest.fixture(scope="function")
-def claimDefGvtId(claimDefGvt):
-    return ID(claimDefGvt.getKey())
+def schemaGvtId(schemaGvt):
+    return ID(schemaGvt.getKey())
 
 
 @pytest.fixture(scope="function")
-def claimDefXyzId(claimDefXyz):
-    return ID(claimDefXyz.getKey())
+def schemaXyzId(schemaXyz):
+    return ID(schemaXyz.getKey())
 
 
 @pytest.fixture(scope="function")
-def keysGvt(primes1, issuerGvt, claimDefGvtId, event_loop):
-    return event_loop.run_until_complete(issuerGvt.genKeys(claimDefGvtId,
+def keysGvt(primes1, issuerGvt, schemaGvtId, event_loop):
+    return event_loop.run_until_complete(issuerGvt.genKeys(schemaGvtId,
                                                            **primes1))
 
 
 @pytest.fixture(scope="function")
-def keysXyz(primes2, issuerXyz, claimDefXyzId, event_loop):
-    return event_loop.run_until_complete(issuerXyz.genKeys(claimDefXyzId,
+def keysXyz(primes2, issuerXyz, schemaXyzId, event_loop):
+    return event_loop.run_until_complete(issuerXyz.genKeys(schemaXyzId,
                                                            **primes2))
 
 
 @pytest.fixture(scope="function")
-def issueAccumulatorGvt(claimDefGvtId, issuerGvt, keysGvt, event_loop):
+def issueAccumulatorGvt(schemaGvtId, issuerGvt, keysGvt, event_loop):
     event_loop.run_until_complete(
-        issuerGvt.issueAccumulator(claimDefId=claimDefGvtId, iA=iA1, L=L))
+        issuerGvt.issueAccumulator(schemaId=schemaGvtId, iA=iA1, L=L))
 
 
 @pytest.fixture(scope="function")
-def issueAccumulatorXyz(claimDefXyzId, issuerXyz, keysXyz, event_loop):
+def issueAccumulatorXyz(schemaXyzId, issuerXyz, keysXyz, event_loop):
     event_loop.run_until_complete(
-        issuerXyz.issueAccumulator(claimDefId=claimDefXyzId, iA=iA2, L=L))
+        issuerXyz.issueAccumulator(schemaId=schemaXyzId, iA=iA2, L=L))
 
 
 @pytest.fixture(scope="function")
-def attrsProver1Gvt(attrRepo, claimDefGvt):
+def attrsProver1Gvt(attrRepo, schemaGvt):
     attrs = GVT.attribs(name='Alex', age=28, height=175, sex='male')
-    attrRepo.addAttributes(claimDefGvt.getKey(), proverId1, attrs)
+    attrRepo.addAttributes(schemaGvt.getKey(), proverId1, attrs)
     return attrs
 
 
 @pytest.fixture(scope="function")
-def attrsProver2Gvt(attrRepo, claimDefGvt):
+def attrsProver2Gvt(attrRepo, schemaGvt):
     attrs = GVT.attribs(name='Jason', age=42, height=180, sex='male')
-    attrRepo.addAttributes(claimDefGvt.getKey(), proverId2, attrs)
+    attrRepo.addAttributes(schemaGvt.getKey(), proverId2, attrs)
     return attrs
 
 
 @pytest.fixture(scope="function")
-def attrsProver1Xyz(attrRepo, claimDefXyz):
+def attrsProver1Xyz(attrRepo, schemaXyz):
     attrs = XYZCorp.attribs(status='partial', period=8)
-    attrRepo.addAttributes(claimDefXyz.getKey(), proverId1, attrs)
+    attrRepo.addAttributes(schemaXyz.getKey(), proverId1, attrs)
     return attrs
 
 
 @pytest.fixture(scope="function")
-def attrsProver2Xyz(attrRepo, claimDefXyz):
+def attrsProver2Xyz(attrRepo, schemaXyz):
     attrs = XYZCorp.attribs(status='full-time', period=22)
-    attrRepo.addAttributes(claimDefXyz.getKey(), proverId2, attrs)
+    attrRepo.addAttributes(schemaXyz.getKey(), proverId2, attrs)
     return attrs
 
 
 @pytest.fixture(scope="function")
-def claimsRequestProver1Gvt(prover1, claimDefGvtId, keysGvt,
+def claimsRequestProver1Gvt(prover1, schemaGvtId, keysGvt,
                             issueAccumulatorGvt, event_loop):
     return event_loop.run_until_complete(
-        prover1.createClaimRequest(claimDefGvtId))
+        prover1.createClaimRequest(schemaGvtId))
 
 
 @pytest.fixture(scope="function")
-def claimsProver1Gvt(prover1, issuerGvt, claimsRequestProver1Gvt, claimDefGvtId,
+def claimsProver1Gvt(prover1, issuerGvt, claimsRequestProver1Gvt, schemaGvtId,
                      attrsProver1Gvt, event_loop):
     claims = event_loop.run_until_complete(
-        issuerGvt.issueClaim(claimDefGvtId, claimsRequestProver1Gvt))
-    event_loop.run_until_complete(prover1.processClaim(claimDefGvtId, claims))
+        issuerGvt.issueClaim(schemaGvtId, claimsRequestProver1Gvt))
+    event_loop.run_until_complete(prover1.processClaim(schemaGvtId, claims))
     return event_loop.run_until_complete(
-        prover1.wallet.getClaims(claimDefGvtId))
+        prover1.wallet.getClaims(schemaGvtId))
 
 
 @pytest.fixture(scope="function")
-def claimsProver2Gvt(prover2, issuerGvt, claimDefGvtId, attrsProver2Gvt,
+def claimsProver2Gvt(prover2, issuerGvt, schemaGvtId, attrsProver2Gvt,
                      keysGvt, issueAccumulatorGvt, event_loop):
     claimsReq = event_loop.run_until_complete(
-        prover2.createClaimRequest(claimDefGvtId))
+        prover2.createClaimRequest(schemaGvtId))
     claims = event_loop.run_until_complete(
-        issuerGvt.issueClaim(claimDefGvtId, claimsReq))
-    event_loop.run_until_complete(prover2.processClaim(claimDefGvtId, claims))
+        issuerGvt.issueClaim(schemaGvtId, claimsReq))
+    event_loop.run_until_complete(prover2.processClaim(schemaGvtId, claims))
     return event_loop.run_until_complete(
-        prover2.wallet.getClaims(claimDefGvtId))
+        prover2.wallet.getClaims(schemaGvtId))
 
 
 @pytest.fixture(scope="function")
-def claimsProver1Xyz(prover1, issuerXyz, claimDefXyzId, attrsProver1Xyz,
+def claimsProver1Xyz(prover1, issuerXyz, schemaXyzId, attrsProver1Xyz,
                      keysXyz, issueAccumulatorXyz, event_loop):
     claimsReq = event_loop.run_until_complete(
-        prover1.createClaimRequest(claimDefXyzId))
+        prover1.createClaimRequest(schemaXyzId))
     claims = event_loop.run_until_complete(
-        issuerXyz.issueClaim(claimDefXyzId, claimsReq))
-    event_loop.run_until_complete(prover1.processClaim(claimDefXyzId, claims))
+        issuerXyz.issueClaim(schemaXyzId, claimsReq))
+    event_loop.run_until_complete(prover1.processClaim(schemaXyzId, claims))
     return event_loop.run_until_complete(
-        prover1.wallet.getClaims(claimDefXyzId))
+        prover1.wallet.getClaims(schemaXyzId))
 
 
 @pytest.fixture(scope="function")
-def claimsProver2Xyz(prover2, issuerXyz, claimDefXyzId, attrsProver2Xyz,
+def claimsProver2Xyz(prover2, issuerXyz, schemaXyzId, attrsProver2Xyz,
                      keysXyz, issueAccumulatorXyz, event_loop):
     claimsReq = event_loop.run_until_complete(
-        prover2.createClaimRequest(claimDefXyzId))
+        prover2.createClaimRequest(schemaXyzId))
     claims = event_loop.run_until_complete(
-        issuerXyz.issueClaim(claimDefXyzId, claimsReq))
-    event_loop.run_until_complete(prover2.processClaim(claimDefXyzId, claims))
+        issuerXyz.issueClaim(schemaXyzId, claimsReq))
+    event_loop.run_until_complete(prover2.processClaim(schemaXyzId, claims))
     return event_loop.run_until_complete(
-        prover2.wallet.getClaims(claimDefXyzId))
+        prover2.wallet.getClaims(schemaXyzId))
 
 
 @pytest.fixture(scope="function")

--- a/anoncreds/test/test_anoncred_usage.py
+++ b/anoncreds/test/test_anoncred_usage.py
@@ -13,6 +13,7 @@ from anoncreds.protocol.wallet.wallet import WalletInMemory
 from anoncreds.test.conftest import GVT, XYZCorp
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testSingleIssuerSingleProver(primes1):
     # 1. Init entities
@@ -52,6 +53,7 @@ async def testSingleIssuerSingleProver(primes1):
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultiplIssuersSingleProver(primes1, primes2):
     # 1. Init entities
@@ -101,6 +103,7 @@ async def testMultiplIssuersSingleProver(primes1, primes2):
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testSingleIssuerMultipleCredDefsSingleProver(primes1, primes2):
     # 1. Init entities

--- a/anoncreds/test/test_anoncred_usage.py
+++ b/anoncreds/test/test_anoncred_usage.py
@@ -21,26 +21,26 @@ async def testSingleIssuerSingleProver(primes1):
     attrRepo = AttributeRepoInMemory()
     issuer = Issuer(IssuerWalletInMemory('issuer1', publicRepo), attrRepo)
 
-    # 2. Create a Claim Def
-    claimDef = await issuer.genClaimDef('GVT', '1.0', GVT.attribNames())
-    claimDefId = ID(claimDef.getKey())
+    # 2. Create a Schema
+    schema = await issuer.genSchema('GVT', '1.0', GVT.attribNames())
+    schemaId = ID(schema.getKey())
 
-    # 3. Create keys for the Claim Def
-    await issuer.genKeys(claimDefId, **primes1)
+    # 3. Create keys for the Schema
+    await issuer.genKeys(schemaId, **primes1)
 
     # 4. Issue accumulator
-    await issuer.issueAccumulator(claimDefId=claimDefId, iA='110', L=5)
+    await issuer.issueAccumulator(schemaId=schemaId, iA='110', L=5)
 
     # 4. set attributes for user1
     userId = '111'
     attrs = GVT.attribs(name='Alex', age=28, height=175, sex='male')
-    attrRepo.addAttributes(claimDef.getKey(), userId, attrs)
+    attrRepo.addAttributes(schema.getKey(), userId, attrs)
 
     # 5. request Claims
     prover = Prover(ProverWalletInMemory(userId, publicRepo))
-    claimsReq = await prover.createClaimRequest(claimDefId)
-    claims = await issuer.issueClaim(claimDefId, claimsReq)
-    await prover.processClaim(claimDefId, claims)
+    claimsReq = await prover.createClaimRequest(schemaId)
+    claims = await issuer.issueClaim(schemaId, claimsReq)
+    await prover.processClaim(schemaId, claims)
 
     # 6. proof Claims
     proofInput = ProofInput(
@@ -62,36 +62,36 @@ async def testMultiplIssuersSingleProver(primes1, primes2):
     issuer1 = Issuer(IssuerWalletInMemory('issuer1', publicRepo), attrRepo)
     issuer2 = Issuer(IssuerWalletInMemory('issuer2', publicRepo), attrRepo)
 
-    # 2. Create a Claim Def
-    claimDef1 = await issuer1.genClaimDef('GVT', '1.0', GVT.attribNames())
-    claimDefId1 = ID(claimDef1.getKey())
-    claimDef2 = await issuer2.genClaimDef('XYZCorp', '1.0',
-                                          XYZCorp.attribNames())
-    claimDefId2 = ID(claimDef2.getKey())
+    # 2. Create a Schema
+    schema1 = await issuer1.genSchema('GVT', '1.0', GVT.attribNames())
+    schemaId1 = ID(schema1.getKey())
+    schema2 = await issuer2.genSchema('XYZCorp', '1.0',
+                                        XYZCorp.attribNames())
+    schemaId2 = ID(schema2.getKey())
 
-    # 3. Create keys for the Claim Def
-    await issuer1.genKeys(claimDefId1, **primes1)
-    await issuer2.genKeys(claimDefId2, **primes2)
+    # 3. Create keys for the Schema
+    await issuer1.genKeys(schemaId1, **primes1)
+    await issuer2.genKeys(schemaId2, **primes2)
 
     # 4. Issue accumulator
-    await issuer1.issueAccumulator(claimDefId=claimDefId1, iA='110', L=5)
-    await issuer2.issueAccumulator(claimDefId=claimDefId2, iA=9999999, L=5)
+    await issuer1.issueAccumulator(schemaId=schemaId1, iA='110', L=5)
+    await issuer2.issueAccumulator(schemaId=schemaId2, iA=9999999, L=5)
 
     # 4. set attributes for user1
     userId = '111'
     attrs1 = GVT.attribs(name='Alex', age=28, height=175, sex='male')
     attrs2 = XYZCorp.attribs(status='FULL', period=8)
-    attrRepo.addAttributes(claimDef1.getKey(), userId, attrs1)
-    attrRepo.addAttributes(claimDef2.getKey(), userId, attrs2)
+    attrRepo.addAttributes(schema1.getKey(), userId, attrs1)
+    attrRepo.addAttributes(schema2.getKey(), userId, attrs2)
 
     # 5. request Claims
     prover = Prover(ProverWalletInMemory(userId, publicRepo))
-    claimsReq1 = await prover.createClaimRequest(claimDefId1)
-    claimsReq2 = await prover.createClaimRequest(claimDefId2)
-    claims1 = await issuer1.issueClaim(claimDefId1, claimsReq1)
-    claims2 = await issuer2.issueClaim(claimDefId2, claimsReq2)
-    await prover.processClaim(claimDefId1, claims1)
-    await prover.processClaim(claimDefId2, claims2)
+    claimsReq1 = await prover.createClaimRequest(schemaId1)
+    claimsReq2 = await prover.createClaimRequest(schemaId2)
+    claims1 = await issuer1.issueClaim(schemaId1, claimsReq1)
+    claims2 = await issuer2.issueClaim(schemaId2, claimsReq2)
+    await prover.processClaim(schemaId1, claims1)
+    await prover.processClaim(schemaId2, claims2)
 
     # 6. proof Claims
     proofInput = ProofInput(['name', 'status'],
@@ -111,31 +111,31 @@ async def testSingleIssuerMultipleCredDefsSingleProver(primes1, primes2):
     attrRepo = AttributeRepoInMemory()
     issuer = Issuer(IssuerWalletInMemory('issuer1', publicRepo), attrRepo)
 
-    # 2. Create a Claim Def
-    claimDef1 = await issuer.genClaimDef('GVT', '1.0', GVT.attribNames())
-    claimDefId1 = ID(claimDef1.getKey())
-    claimDef2 = await issuer.genClaimDef('XYZCorp', '1.0',
-                                         XYZCorp.attribNames())
-    claimDefId2 = ID(claimDef2.getKey())
+    # 2. Create a Schema
+    schema1 = await issuer.genSchema('GVT', '1.0', GVT.attribNames())
+    schemaId1 = ID(schema1.getKey())
+    schema2 = await issuer.genSchema('XYZCorp', '1.0',
+                                       XYZCorp.attribNames())
+    schemaId2 = ID(schema2.getKey())
 
-    # 3. Create keys for the Claim Def
-    await issuer.genKeys(claimDefId1, **primes1)
-    await issuer.genKeys(claimDefId2, **primes2)
+    # 3. Create keys for the Schema
+    await issuer.genKeys(schemaId1, **primes1)
+    await issuer.genKeys(schemaId2, **primes2)
 
     # 4. Issue accumulator
-    await issuer.issueAccumulator(claimDefId=claimDefId1, iA='110', L=5)
-    await issuer.issueAccumulator(claimDefId=claimDefId2, iA=9999999, L=5)
+    await issuer.issueAccumulator(schemaId=schemaId1, iA='110', L=5)
+    await issuer.issueAccumulator(schemaId=schemaId2, iA=9999999, L=5)
 
     # 4. set attributes for user1
     userId = '111'
     attrs1 = GVT.attribs(name='Alex', age=28, height=175, sex='male')
     attrs2 = XYZCorp.attribs(status='FULL', period=8)
-    attrRepo.addAttributes(claimDef1.getKey(), userId, attrs1)
-    attrRepo.addAttributes(claimDef2.getKey(), userId, attrs2)
+    attrRepo.addAttributes(schema1.getKey(), userId, attrs1)
+    attrRepo.addAttributes(schema2.getKey(), userId, attrs2)
 
     # 5. request Claims
     prover = Prover(ProverWalletInMemory(userId, publicRepo))
-    claimsReqs = await prover.createClaimRequests([claimDefId1, claimDefId2])
+    claimsReqs = await prover.createClaimRequests([schemaId1, schemaId2])
     claims = await issuer.issueClaims(claimsReqs)
     await prover.processClaims(claims)
 
@@ -157,26 +157,26 @@ async def testSingleIssuerSingleProverPrimaryOnly(primes1):
     attrRepo = AttributeRepoInMemory()
     issuer = Issuer(IssuerWalletInMemory('issuer1', publicRepo), attrRepo)
 
-    # 2. Create a Claim Def
-    claimDef = await issuer.genClaimDef('GVT', '1.0', GVT.attribNames())
-    claimDefId = ID(claimDef.getKey())
+    # 2. Create a Schema
+    schema = await issuer.genSchema('GVT', '1.0', GVT.attribNames())
+    schemaId = ID(schema.getKey())
 
-    # 3. Create keys for the Claim Def
-    await issuer.genKeys(claimDefId, **primes1)
+    # 3. Create keys for the Schema
+    await issuer.genKeys(schemaId, **primes1)
 
     # 4. Issue accumulator
-    await issuer.issueAccumulator(claimDefId=claimDefId, iA='110', L=5)
+    await issuer.issueAccumulator(schemaId=schemaId, iA='110', L=5)
 
     # 4. set attributes for user1
     userId = '111'
     attrs = GVT.attribs(name='Alex', age=28, height=175, sex='male')
-    attrRepo.addAttributes(claimDef.getKey(), userId, attrs)
+    attrRepo.addAttributes(schema.getKey(), userId, attrs)
 
     # 5. request Claims
     prover = Prover(ProverWalletInMemory(userId, publicRepo))
-    claimsReq = await prover.createClaimRequest(claimDefId, None, False)
-    claims = await issuer.issueClaim(claimDefId, claimsReq)
-    await prover.processClaim(claimDefId, claims)
+    claimsReq = await prover.createClaimRequest(schemaId, None, False)
+    claims = await issuer.issueClaim(schemaId, claimsReq)
+    await prover.processClaim(schemaId, claims)
 
     # 6. proof Claims
     proofInput = ProofInput(

--- a/anoncreds/test/test_find_claims_for_input.py
+++ b/anoncreds/test/test_find_claims_for_input.py
@@ -3,12 +3,14 @@ import pytest
 from anoncreds.protocol.types import ProofInput, ProofClaims, PredicateGE
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testEmpty(prover1, allClaims):
     proofInput = ProofInput([], [])
     assert ({}, {}) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testOneRevealedOnly(prover1, allClaims, claimDefGvtId, attrRepo):
     proofInput = ProofInput(['name'])
@@ -22,6 +24,7 @@ async def testOneRevealedOnly(prover1, allClaims, claimDefGvtId, attrRepo):
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPredicatesEmpty(prover1, allClaims, claimDefGvtId, attrRepo):
     proofInput = ProofInput(['name'], [])
@@ -35,6 +38,7 @@ async def testPredicatesEmpty(prover1, allClaims, claimDefGvtId, attrRepo):
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testOnePredicateOnly(prover1, allClaims, claimDefGvtId):
     proofInput = ProofInput(predicates=[PredicateGE('age', 18)])
@@ -45,6 +49,7 @@ async def testOnePredicateOnly(prover1, allClaims, claimDefGvtId):
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevealedEmpty(prover1, allClaims, claimDefGvtId):
     proofInput = ProofInput([], [PredicateGE('age', 18)])
@@ -55,6 +60,7 @@ async def testRevealedEmpty(prover1, allClaims, claimDefGvtId):
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevealedAndPredicateSameIssuer(prover1, allClaims, claimDefGvtId,
                                              attrRepo):
@@ -70,6 +76,7 @@ async def testRevealedAndPredicateSameIssuer(prover1, allClaims, claimDefGvtId,
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevealedAndPredicateDifferentIssuers(prover1, allClaims,
                                                    claimDefGvtId, claimDefXyzId,
@@ -88,6 +95,7 @@ async def testRevealedAndPredicateDifferentIssuers(prover1, allClaims,
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipledRevealed(prover1, allClaims, claimDefGvtId,
                                 claimDefXyzId, attrRepo):
@@ -110,6 +118,7 @@ async def testMultipledRevealed(prover1, allClaims, claimDefGvtId,
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipledPredicates(prover1, allClaims, claimDefGvtId,
                                   claimDefXyzId):
@@ -125,6 +134,7 @@ async def testMultipledPredicates(prover1, allClaims, claimDefGvtId,
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleAll(prover1, allClaims, claimDefGvtId, claimDefXyzId,
                           attrRepo):
@@ -150,6 +160,7 @@ async def testMultipleAll(prover1, allClaims, claimDefGvtId, claimDefXyzId,
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testAttrNotFound(prover1, allClaims):
     proofInput = ProofInput(['name', 'aaaa'], [])
@@ -157,6 +168,7 @@ async def testAttrNotFound(prover1, allClaims):
         await prover1._findClaims(proofInput)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPredicateNotFound(prover1, allClaims):
     proofInput = ProofInput([],

--- a/anoncreds/test/test_find_claims_for_input.py
+++ b/anoncreds/test/test_find_claims_for_input.py
@@ -12,13 +12,13 @@ async def testEmpty(prover1, allClaims):
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testOneRevealedOnly(prover1, allClaims, claimDefGvtId, attrRepo):
+async def testOneRevealedOnly(prover1, allClaims, schemaGvtId, attrRepo):
     proofInput = ProofInput(['name'])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, ['name'], [])}
     revealedAttrs = {'name':
-                         attrRepo.getAttributes(claimDefGvtId.claimDefKey,
+                         attrRepo.getAttributes(schemaGvtId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'name']}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -26,13 +26,13 @@ async def testOneRevealedOnly(prover1, allClaims, claimDefGvtId, attrRepo):
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testPredicatesEmpty(prover1, allClaims, claimDefGvtId, attrRepo):
+async def testPredicatesEmpty(prover1, allClaims, schemaGvtId, attrRepo):
     proofInput = ProofInput(['name'], [])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, ['name'], [])}
     revealedAttrs = {'name':
-                         attrRepo.getAttributes(claimDefGvtId.claimDefKey,
+                         attrRepo.getAttributes(schemaGvtId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'name']}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -40,10 +40,10 @@ async def testPredicatesEmpty(prover1, allClaims, claimDefGvtId, attrRepo):
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testOnePredicateOnly(prover1, allClaims, claimDefGvtId):
+async def testOnePredicateOnly(prover1, allClaims, schemaGvtId):
     proofInput = ProofInput(predicates=[PredicateGE('age', 18)])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, [], [PredicateGE('age', 18)])}
     revealedAttrs = {}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -51,10 +51,10 @@ async def testOnePredicateOnly(prover1, allClaims, claimDefGvtId):
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testRevealedEmpty(prover1, allClaims, claimDefGvtId):
+async def testRevealedEmpty(prover1, allClaims, schemaGvtId):
     proofInput = ProofInput([], [PredicateGE('age', 18)])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, [], [PredicateGE('age', 18)])}
     revealedAttrs = {}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -62,15 +62,15 @@ async def testRevealedEmpty(prover1, allClaims, claimDefGvtId):
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testRevealedAndPredicateSameIssuer(prover1, allClaims, claimDefGvtId,
+async def testRevealedAndPredicateSameIssuer(prover1, allClaims, schemaGvtId,
                                              attrRepo):
     proofInput = ProofInput(['name'], [PredicateGE('age', 18)])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, ['name'],
                                    [PredicateGE('age', 18)])}
     revealedAttrs = {'name':
-                         attrRepo.getAttributes(claimDefGvtId.claimDefKey,
+                         attrRepo.getAttributes(schemaGvtId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'name']}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -79,17 +79,17 @@ async def testRevealedAndPredicateSameIssuer(prover1, allClaims, claimDefGvtId,
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevealedAndPredicateDifferentIssuers(prover1, allClaims,
-                                                   claimDefGvtId, claimDefXyzId,
+                                                   schemaGvtId, schemaXyzId,
                                                    attrRepo):
     proofInput = ProofInput(['status'], [PredicateGE('age', 18)])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    claimsXyz = await prover1.wallet.getClaims(claimDefXyzId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    claimsXyz = await prover1.wallet.getClaims(schemaXyzId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, [], [PredicateGE('age', 18)]),
-                   claimDefXyzId.claimDefKey:
+                   schemaXyzId.schemaKey:
                        ProofClaims(claimsXyz, ['status'], [])}
     revealedAttrs = {'status':
-                         attrRepo.getAttributes(claimDefXyzId.claimDefKey,
+                         attrRepo.getAttributes(schemaXyzId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'status']}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -97,21 +97,21 @@ async def testRevealedAndPredicateDifferentIssuers(prover1, allClaims,
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testMultipledRevealed(prover1, allClaims, claimDefGvtId,
-                                claimDefXyzId, attrRepo):
+async def testMultipledRevealed(prover1, allClaims, schemaGvtId,
+                                schemaXyzId, attrRepo):
     proofInput = ProofInput(['status', 'name'], [])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    claimsXyz = await prover1.wallet.getClaims(claimDefXyzId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    claimsXyz = await prover1.wallet.getClaims(schemaXyzId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, ['name'], []),
-                   claimDefXyzId.claimDefKey:
+                   schemaXyzId.schemaKey:
                        ProofClaims(claimsXyz, ['status'], [])}
     revealedAttrs = {'name':
-                         attrRepo.getAttributes(claimDefGvtId.claimDefKey,
+                         attrRepo.getAttributes(schemaGvtId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'name'],
                      'status':
-                         attrRepo.getAttributes(claimDefXyzId.claimDefKey,
+                         attrRepo.getAttributes(schemaXyzId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'status'],
                      }
@@ -120,15 +120,15 @@ async def testMultipledRevealed(prover1, allClaims, claimDefGvtId,
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testMultipledPredicates(prover1, allClaims, claimDefGvtId,
-                                  claimDefXyzId):
+async def testMultipledPredicates(prover1, allClaims, schemaGvtId,
+                                  schemaXyzId):
     proofInput = ProofInput([],
                             [PredicateGE('age', 18), PredicateGE('period', 8)])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    claimsXyz = await prover1.wallet.getClaims(claimDefXyzId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    claimsXyz = await prover1.wallet.getClaims(schemaXyzId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, [], [PredicateGE('age', 18)]),
-                   claimDefXyzId.claimDefKey:
+                   schemaXyzId.schemaKey:
                        ProofClaims(claimsXyz, [], [PredicateGE('period', 8)])}
     revealedAttrs = {}
     assert (proofClaims, revealedAttrs) == await prover1._findClaims(proofInput)
@@ -136,24 +136,24 @@ async def testMultipledPredicates(prover1, allClaims, claimDefGvtId,
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testMultipleAll(prover1, allClaims, claimDefGvtId, claimDefXyzId,
+async def testMultipleAll(prover1, allClaims, schemaGvtId, schemaXyzId,
                           attrRepo):
     proofInput = ProofInput(['status', 'name'],
                             [PredicateGE('age', 18), PredicateGE('period', 8)])
-    claimsGvt = await prover1.wallet.getClaims(claimDefGvtId)
-    claimsXyz = await prover1.wallet.getClaims(claimDefXyzId)
-    proofClaims = {claimDefGvtId.claimDefKey:
+    claimsGvt = await prover1.wallet.getClaims(schemaGvtId)
+    claimsXyz = await prover1.wallet.getClaims(schemaXyzId)
+    proofClaims = {schemaGvtId.schemaKey:
                        ProofClaims(claimsGvt, ['name'],
                                    [PredicateGE('age', 18)]),
-                   claimDefXyzId.claimDefKey:
+                   schemaXyzId.schemaKey:
                        ProofClaims(claimsXyz, ['status'],
                                    [PredicateGE('period', 8)])}
     revealedAttrs = {'name':
-                         attrRepo.getAttributes(claimDefGvtId.claimDefKey,
+                         attrRepo.getAttributes(schemaGvtId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'name'],
                      'status':
-                         attrRepo.getAttributes(claimDefXyzId.claimDefKey,
+                         attrRepo.getAttributes(schemaXyzId.schemaKey,
                                                 prover1.proverId).encoded()[
                              'status'],
                      }

--- a/anoncreds/test/test_multiple_prover_multiple_issuers.py
+++ b/anoncreds/test/test_multiple_prover_multiple_issuers.py
@@ -4,6 +4,7 @@ from anoncreds.protocol.types import ProofInput, PredicateGE
 from anoncreds.test.conftest import presentProofAndVerify
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testNoPredicates(prover1, prover2, verifier, allClaims):
     proofInput = ProofInput(['name', 'status'], [])
@@ -11,6 +12,7 @@ async def testNoPredicates(prover1, prover2, verifier, allClaims):
     assert await presentProofAndVerify(verifier, proofInput, prover2)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicate(prover1, prover2, verifier, allClaims):
     proofInput = ProofInput(['name'],
@@ -20,6 +22,7 @@ async def testGePredicate(prover1, prover2, verifier, allClaims):
     assert await presentProofAndVerify(verifier, proofInput, prover2)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicateNegativeForOne(prover1, prover2, verifier, allClaims):
     proofInput = ProofInput(['name'],
@@ -30,6 +33,7 @@ async def testGePredicateNegativeForOne(prover1, prover2, verifier, allClaims):
         await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicateNegativeForBoth(prover1, prover2, verifier, allClaims):
     proofInput = ProofInput(['name'],

--- a/anoncreds/test/test_non_revocation.py
+++ b/anoncreds/test/test_non_revocation.py
@@ -5,6 +5,7 @@ from anoncreds.protocol.utils import groupIdentityG1
 from anoncreds.test.conftest import presentProofAndVerify
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testIssueRevocationCredential(claimsProver1Gvt, issuerGvt,
                                         claimDefGvtId):
@@ -23,6 +24,7 @@ async def testIssueRevocationCredential(claimsProver1Gvt, issuerGvt,
     assert nonRevocClaimGvtProver1.witness.V == acc.V
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevoce(claimsProver1Gvt, issuerGvt, claimDefGvtId):
     await issuerGvt.revoke(claimDefGvtId, 1)
@@ -31,6 +33,7 @@ async def testRevoce(claimsProver1Gvt, issuerGvt, claimDefGvtId):
     assert newAcc.acc == groupIdentityG1()
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testUpdateWitnessNotChangedIfInSync(claimsProver1Gvt, claimDefGvtId,
                                               prover1):
@@ -47,6 +50,7 @@ async def testUpdateWitnessNotChangedIfInSync(claimsProver1Gvt, claimDefGvtId,
     assert oldOmega == c2.witness.omega
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testUpdateWitnessChangedIfOutOfSync(claimsProver1Gvt, issuerGvt,
                                               claimDefGvtId, prover1):
@@ -66,6 +70,7 @@ async def testUpdateWitnessChangedIfOutOfSync(claimsProver1Gvt, issuerGvt,
     assert oldOmega != c2.witness.omega
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testUpdateRevocedWitness(claimsProver1Gvt, issuerGvt, claimDefGvtId,
                                    prover1):
@@ -76,6 +81,7 @@ async def testUpdateRevocedWitness(claimsProver1Gvt, issuerGvt, claimDefGvtId,
             claimDefGvtId.claimDefKey, nonRevocClaimGvtProver1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testInitNonRevocClaim(claimDefGvtId, prover1, issuerGvt,
                                 attrsProver1Gvt, keysGvt, issueAccumulatorGvt):
@@ -91,6 +97,7 @@ async def testInitNonRevocClaim(claimDefGvtId, prover1, issuerGvt,
     assert oldV + vrPrime == newC2.v
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testCAndTauList(claimsProver1Gvt, claimDefGvtId, prover1):
     nonRevocClaimGvtProver1 = claimsProver1Gvt.nonRevocClaim
@@ -99,6 +106,7 @@ async def testCAndTauList(claimsProver1Gvt, claimDefGvtId, prover1):
                                            nonRevocClaimGvtProver1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevocedWithUpdateWitness(claimDefGvtId, issuerGvt, prover1,
                                        verifier, claimsProver1Gvt):
@@ -109,6 +117,7 @@ async def testRevocedWithUpdateWitness(claimDefGvtId, issuerGvt, prover1,
         await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevocedWithoutUpdateWitness(claimDefGvtId, issuerGvt, prover1,
                                           verifier, claimsProver1Gvt):

--- a/anoncreds/test/test_non_revocation.py
+++ b/anoncreds/test/test_non_revocation.py
@@ -8,10 +8,10 @@ from anoncreds.test.conftest import presentProofAndVerify
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testIssueRevocationCredential(claimsProver1Gvt, issuerGvt,
-                                        claimDefGvtId):
+                                        schemaGvtId):
     nonRevocClaimGvtProver1 = claimsProver1Gvt.nonRevocClaim
-    acc = await issuerGvt.wallet.getAccumulator(claimDefGvtId)
-    tails = await issuerGvt.wallet.getTails(claimDefGvtId)
+    acc = await issuerGvt.wallet.getAccumulator(schemaGvtId)
+    tails = await issuerGvt.wallet.getTails(schemaGvtId)
     assert nonRevocClaimGvtProver1
     assert nonRevocClaimGvtProver1.witness
     assert nonRevocClaimGvtProver1.witness.V
@@ -26,25 +26,25 @@ async def testIssueRevocationCredential(claimsProver1Gvt, issuerGvt,
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testRevoce(claimsProver1Gvt, issuerGvt, claimDefGvtId):
-    await issuerGvt.revoke(claimDefGvtId, 1)
-    newAcc = await issuerGvt.wallet.getAccumulator(claimDefGvtId)
+async def testRevoce(claimsProver1Gvt, issuerGvt, schemaGvtId):
+    await issuerGvt.revoke(schemaGvtId, 1)
+    newAcc = await issuerGvt.wallet.getAccumulator(schemaGvtId)
     assert not newAcc.V
     assert newAcc.acc == groupIdentityG1()
 
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testUpdateWitnessNotChangedIfInSync(claimsProver1Gvt, claimDefGvtId,
+async def testUpdateWitnessNotChangedIfInSync(claimsProver1Gvt, schemaGvtId,
                                               prover1):
     nonRevocClaimGvtProver1 = claimsProver1Gvt.nonRevocClaim
-    acc = await prover1.wallet.getAccumulator(claimDefGvtId)
+    acc = await prover1.wallet.getAccumulator(schemaGvtId)
 
     # not changed as in sync
     oldOmega = nonRevocClaimGvtProver1.witness.omega
 
     c2 = await prover1._nonRevocProofBuilder.updateNonRevocationClaim(
-        claimDefGvtId.claimDefKey,
+        schemaGvtId.schemaKey,
         nonRevocClaimGvtProver1)
     assert c2.witness.V == acc.V
     assert oldOmega == c2.witness.omega
@@ -53,9 +53,9 @@ async def testUpdateWitnessNotChangedIfInSync(claimsProver1Gvt, claimDefGvtId,
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testUpdateWitnessChangedIfOutOfSync(claimsProver1Gvt, issuerGvt,
-                                              claimDefGvtId, prover1):
+                                              schemaGvtId, prover1):
     nonRevocClaimGvtProver1 = claimsProver1Gvt.nonRevocClaim
-    acc = await issuerGvt.wallet.getAccumulator(claimDefGvtId)
+    acc = await issuerGvt.wallet.getAccumulator(schemaGvtId)
 
     # not in sync
     acc.V.add(3)
@@ -64,7 +64,7 @@ async def testUpdateWitnessChangedIfOutOfSync(claimsProver1Gvt, issuerGvt,
     # witness is updated
     oldOmega = nonRevocClaimGvtProver1.witness.omega
     c2 = await prover1._nonRevocProofBuilder.updateNonRevocationClaim(
-        claimDefGvtId.claimDefKey,
+        schemaGvtId.schemaKey,
         nonRevocClaimGvtProver1)
     assert c2.witness.V == acc.V
     assert oldOmega != c2.witness.omega
@@ -72,45 +72,45 @@ async def testUpdateWitnessChangedIfOutOfSync(claimsProver1Gvt, issuerGvt,
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testUpdateRevocedWitness(claimsProver1Gvt, issuerGvt, claimDefGvtId,
+async def testUpdateRevocedWitness(claimsProver1Gvt, issuerGvt, schemaGvtId,
                                    prover1):
     nonRevocClaimGvtProver1 = claimsProver1Gvt.nonRevocClaim
-    await issuerGvt.revoke(claimDefGvtId, 1)
+    await issuerGvt.revoke(schemaGvtId, 1)
     with pytest.raises(ValueError):
         await prover1._nonRevocProofBuilder.updateNonRevocationClaim(
-            claimDefGvtId.claimDefKey, nonRevocClaimGvtProver1)
+            schemaGvtId.schemaKey, nonRevocClaimGvtProver1)
 
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testInitNonRevocClaim(claimDefGvtId, prover1, issuerGvt,
+async def testInitNonRevocClaim(schemaGvtId, prover1, issuerGvt,
                                 attrsProver1Gvt, keysGvt, issueAccumulatorGvt):
-    claimsReq = await prover1.createClaimRequest(claimDefGvtId)
-    claims = await issuerGvt.issueClaim(claimDefGvtId, claimsReq)
+    claimsReq = await prover1.createClaimRequest(schemaGvtId)
+    claims = await issuerGvt.issueClaim(schemaGvtId, claimsReq)
 
     oldV = claims.nonRevocClaim.v
-    await prover1.processClaim(claimDefGvtId, claims)
-    newC2 = (await prover1.wallet.getClaims(claimDefGvtId)).nonRevocClaim
+    await prover1.processClaim(schemaGvtId, claims)
+    newC2 = (await prover1.wallet.getClaims(schemaGvtId)).nonRevocClaim
     vrPrime = (
-        await prover1.wallet.getNonRevocClaimInitData(claimDefGvtId)).vPrime
+        await prover1.wallet.getNonRevocClaimInitData(schemaGvtId)).vPrime
 
     assert oldV + vrPrime == newC2.v
 
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testCAndTauList(claimsProver1Gvt, claimDefGvtId, prover1):
+async def testCAndTauList(claimsProver1Gvt, schemaGvtId, prover1):
     nonRevocClaimGvtProver1 = claimsProver1Gvt.nonRevocClaim
     proofRevBuilder = prover1._nonRevocProofBuilder
-    assert await proofRevBuilder.testProof(claimDefGvtId.claimDefKey,
+    assert await proofRevBuilder.testProof(schemaGvtId.schemaKey,
                                            nonRevocClaimGvtProver1)
 
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testRevocedWithUpdateWitness(claimDefGvtId, issuerGvt, prover1,
+async def testRevocedWithUpdateWitness(schemaGvtId, issuerGvt, prover1,
                                        verifier, claimsProver1Gvt):
-    await issuerGvt.revoke(claimDefGvtId, 1)
+    await issuerGvt.revoke(schemaGvtId, 1)
 
     proofInput = ProofInput(['name'], [])
     with pytest.raises(ValueError):
@@ -119,12 +119,12 @@ async def testRevocedWithUpdateWitness(claimDefGvtId, issuerGvt, prover1,
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testRevocedWithoutUpdateWitness(claimDefGvtId, issuerGvt, prover1,
+async def testRevocedWithoutUpdateWitness(schemaGvtId, issuerGvt, prover1,
                                           verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [])
     nonce = verifier.generateNonce()
     proof, revealedAttrs = await prover1.presentProof(proofInput, nonce)
 
-    await issuerGvt.revoke(claimDefGvtId, 1)
+    await issuerGvt.revoke(schemaGvtId, 1)
 
     return await verifier.verify(proofInput, proof, revealedAttrs, nonce)

--- a/anoncreds/test/test_single_prover_multiple_issuers.py
+++ b/anoncreds/test/test_single_prover_multiple_issuers.py
@@ -4,24 +4,28 @@ from anoncreds.protocol.types import ProofInput, PredicateGE
 from anoncreds.test.conftest import presentProofAndVerify
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testNoPredicates(prover1, verifier, claimsProver1):
     proofInput = ProofInput(['name', 'status'], [])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicate(prover1, verifier, claimsProver1):
     proofInput = ProofInput(['name'], [PredicateGE('period', 5)])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicateForEqual(prover1, verifier, claimsProver1):
     proofInput = ProofInput(['name'], [PredicateGE('period', 8)])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicateNegative(prover1, verifier, claimsProver1):
     proofInput = ProofInput(['name'], [PredicateGE('period', 9)])
@@ -29,6 +33,7 @@ async def testGePredicateNegative(prover1, verifier, claimsProver1):
         await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleGePredicate(prover1, verifier, claimsProver1):
     proofInput = ProofInput(['name'],
@@ -37,6 +42,7 @@ async def testMultipleGePredicate(prover1, verifier, claimsProver1):
     await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleGePredicateMultipleRevealed(prover1, verifier,
                                                   claimsProver1):
@@ -46,6 +52,7 @@ async def testMultipleGePredicateMultipleRevealed(prover1, verifier,
     await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleGePredicateNegative(prover1, verifier, claimsProver1):
     proofInput = ProofInput(['name'],

--- a/anoncreds/test/test_single_prover_single_issuer.py
+++ b/anoncreds/test/test_single_prover_single_issuer.py
@@ -5,6 +5,7 @@ from anoncreds.protocol.types import ProofInput, PredicateGE, Claims, \
 from anoncreds.test.conftest import presentProofAndVerify
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPrimaryClaimOnlyEmpty(prover1, verifier, claimsProver1Gvt, nonce):
     proofInput = ProofInput([])
@@ -16,6 +17,7 @@ async def testPrimaryClaimOnlyEmpty(prover1, verifier, claimsProver1Gvt, nonce):
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPrimaryClaimNoPredicates(prover1, verifier, claimsProver1Gvt,
                                        nonce, claimDefGvtId,
@@ -32,6 +34,7 @@ async def testPrimaryClaimNoPredicates(prover1, verifier, claimsProver1Gvt,
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPrimaryClaimPredicatesOnly(prover1, verifier, claimsProver1Gvt,
                                          nonce, claimDefGvtId,
@@ -47,35 +50,41 @@ async def testPrimaryClaimPredicatesOnly(prover1, verifier, claimsProver1Gvt,
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testEmpty(prover1, verifier, claimsProver1Gvt):
     assert await presentProofAndVerify(verifier, ProofInput(), prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testNoPredicates(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleRevealedAttrs(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name', 'sex'], [])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicate(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [PredicateGE('age', 18)])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicateForEqual(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [PredicateGE('age', 28)])
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testGePredicateNegative(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [PredicateGE('age', 29)])
@@ -83,6 +92,7 @@ async def testGePredicateNegative(prover1, verifier, claimsProver1Gvt):
         await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleGePredicate(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'],
@@ -91,6 +101,7 @@ async def testMultipleGePredicate(prover1, verifier, claimsProver1Gvt):
     assert await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testMultipleGePredicateNegative(prover1, verifier, claimsProver1Gvt):
     proofInput = ProofInput(['name'],
@@ -100,6 +111,7 @@ async def testMultipleGePredicateNegative(prover1, verifier, claimsProver1Gvt):
         await presentProofAndVerify(verifier, proofInput, prover1)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testNonceShouldBeSame(prover1, verifier, claimsProver1Gvt, nonce,
                                 genNonce):
@@ -109,6 +121,7 @@ async def testNonceShouldBeSame(prover1, verifier, claimsProver1Gvt, nonce,
     assert not await verifier.verify(proofInput, proof, revealedAttrs, genNonce)
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testAttrsInClaims(claimsProver1Gvt, attrsProver1Gvt):
     attrs = claimsProver1Gvt.primaryClaim.attrs
     encodedAttrs = claimsProver1Gvt.primaryClaim.encodedAttrs
@@ -119,6 +132,7 @@ def testAttrsInClaims(claimsProver1Gvt, attrsProver1Gvt):
     assert encodedAttrs.keys() == attrsProver1Gvt.keys()
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testUParamShouldBeSame(prover1, verifier, issuerGvt, claimDefGvtId,
                                  attrsProver1Gvt, keysGvt,

--- a/anoncreds/test/test_single_prover_single_issuer.py
+++ b/anoncreds/test/test_single_prover_single_issuer.py
@@ -10,9 +10,9 @@ from anoncreds.test.conftest import presentProofAndVerify
 async def testPrimaryClaimOnlyEmpty(prover1, verifier, claimsProver1Gvt, nonce):
     proofInput = ProofInput([])
     claims, revealedAttrs = await prover1._findClaims(proofInput)
-    claims = {claimDefKey: ProofClaims(
+    claims = {schemaKey: ProofClaims(
         Claims(primaryClaim=proofClaim.claims.primaryClaim))
-              for claimDefKey, proofClaim in claims.items()}
+              for schemaKey, proofClaim in claims.items()}
     proof = await prover1._prepareProof(claims, nonce)
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
@@ -20,16 +20,16 @@ async def testPrimaryClaimOnlyEmpty(prover1, verifier, claimsProver1Gvt, nonce):
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPrimaryClaimNoPredicates(prover1, verifier, claimsProver1Gvt,
-                                       nonce, claimDefGvtId,
+                                       nonce, schemaGvtId,
                                        attrRepo):
     revealledAttrs = ['name']
     proofInput = ProofInput(revealledAttrs)
     claims, revealedAttrs = await prover1._findClaims(proofInput)
     claims = {
-        claimDefKey: ProofClaims(
+        schemaKey: ProofClaims(
             Claims(primaryClaim=proofClaim.claims.primaryClaim),
             revealedAttrs=revealledAttrs)
-        for claimDefKey, proofClaim in claims.items()}
+        for schemaKey, proofClaim in claims.items()}
     proof = await prover1._prepareProof(claims, nonce)
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
@@ -37,15 +37,15 @@ async def testPrimaryClaimNoPredicates(prover1, verifier, claimsProver1Gvt,
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testPrimaryClaimPredicatesOnly(prover1, verifier, claimsProver1Gvt,
-                                         nonce, claimDefGvtId,
+                                         nonce, schemaGvtId,
                                          attrRepo):
     predicates = [PredicateGE('age', 18)]
     proofInput = ProofInput(predicates=predicates)
     claims, revealedAttrs = await prover1._findClaims(proofInput)
-    claims = {claimDefKey: ProofClaims(
+    claims = {schemaKey: ProofClaims(
         Claims(primaryClaim=proofClaim.claims.primaryClaim),
         predicates=predicates)
-              for claimDefKey, proofClaim in claims.items()}
+              for schemaKey, proofClaim in claims.items()}
     proof = await prover1._prepareProof(claims, nonce)
     assert await verifier.verify(proofInput, proof, revealedAttrs, nonce)
 
@@ -134,27 +134,27 @@ def testAttrsInClaims(claimsProver1Gvt, attrsProver1Gvt):
 
 @pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
-async def testUParamShouldBeSame(prover1, verifier, issuerGvt, claimDefGvtId,
+async def testUParamShouldBeSame(prover1, verifier, issuerGvt, schemaGvtId,
                                  attrsProver1Gvt, keysGvt,
                                  issueAccumulatorGvt):
-    claimsReq = await prover1.createClaimRequest(claimDefGvtId)
+    claimsReq = await prover1.createClaimRequest(schemaGvtId)
 
     claimsReq = claimsReq._replace(U=claimsReq.U ** 2)
-    claims = await issuerGvt.issueClaim(claimDefGvtId, claimsReq)
-    await prover1.processClaim(claimDefGvtId, claims)
+    claims = await issuerGvt.issueClaim(schemaGvtId, claimsReq)
+    await prover1.processClaim(schemaGvtId, claims)
 
     proofInput = ProofInput(['name'], [])
     assert not await presentProofAndVerify(verifier, proofInput, prover1)
 
 
 @pytest.mark.asyncio
-async def testUrParamShouldBeSame(prover1, issuerGvt, claimDefGvtId,
+async def testUrParamShouldBeSame(prover1, issuerGvt, schemaGvtId,
                                   attrsProver1Gvt, keysGvt,
                                   issueAccumulatorGvt):
-    claimsReq = await prover1.createClaimRequest(claimDefGvtId)
+    claimsReq = await prover1.createClaimRequest(schemaGvtId)
 
     claimsReq = claimsReq._replace(Ur=claimsReq.Ur ** 2)
-    claims = await issuerGvt.issueClaim(claimDefGvtId, claimsReq)
+    claims = await issuerGvt.issueClaim(schemaGvtId, claimsReq)
 
     with pytest.raises(ValueError):
-        await prover1.processClaim(claimDefGvtId, claims)
+        await prover1.processClaim(schemaGvtId, claims)

--- a/anoncreds/test/test_types.py
+++ b/anoncreds/test/test_types.py
@@ -32,20 +32,24 @@ def testPKFromToDict():
     assert pk == PublicKey.fromStrDict(pk.toStrDict())
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testRequestClaimsFromToDict(claimsRequestProver1Gvt):
     assert claimsRequestProver1Gvt == ClaimRequest.fromStrDict(
         claimsRequestProver1Gvt.toStrDict())
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testClaimsFromToDict(claimsProver1Gvt):
     assert claimsProver1Gvt == Claims.fromStrDict(claimsProver1Gvt.toStrDict())
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testClaimsFromToDictPrimaryOnly(claimsProver1Gvt):
     claims = Claims(primaryClaim=claimsProver1Gvt.primaryClaim)
     assert claims == Claims.fromStrDict(claims.toStrDict())
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testClaimProofFromToDict(prover1, nonce, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [PredicateGE('age', 18)])
@@ -53,6 +57,7 @@ async def testClaimProofFromToDict(prover1, nonce, claimsProver1Gvt):
     assert proof == FullProof.fromStrDict(proof.toStrDict())
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testClaimProofFromToDictPrimaryOnly(prover1, nonce, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [PredicateGE('age', 18)])
@@ -69,6 +74,7 @@ def testProofInputFromToDict():
     assert proofInput == ProofInput.fromStrDict(proofInput.toStrDict())
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 @pytest.mark.asyncio
 async def testRevealedAttrsFromToDict(prover1, nonce, claimsProver1Gvt):
     proofInput = ProofInput(['name'], [PredicateGE('age', 18)])

--- a/anoncreds/test/test_types.py
+++ b/anoncreds/test/test_types.py
@@ -1,25 +1,25 @@
 import pytest
 
-from anoncreds.protocol.types import PublicKey, ClaimDefinition, Claims, \
+from anoncreds.protocol.types import PublicKey, Schema, Claims, \
     ProofInput, PredicateGE, FullProof, \
-    ClaimDefinitionKey, ClaimRequest, Proof
+    SchemaKey, ClaimRequest, Proof
 from anoncreds.protocol.utils import toDictWithStrValues, fromDictWithStrValues
 from config.config import cmod
 
 
-def testClaimDefKeyFromToDict():
-    claimDefKey = ClaimDefinitionKey(name='claimDefName', version='1.0',
-                                     issuerId='issuer1')
-    assert claimDefKey == ClaimDefinitionKey.fromStrDict(
-        claimDefKey.toStrDict())
+def testSchemaKeyFromToDict():
+    schemaKey = SchemaKey(name='schemaName', version='1.0',
+                            issuerId='issuer1')
+    assert schemaKey == SchemaKey.fromStrDict(
+        schemaKey.toStrDict())
 
 
-def testClaimDefFromToDict():
-    claimDef = ClaimDefinition(name='claimDefName', version='1.0',
-                               claimDefType='CL',
-                               attrNames=['attr1', 'attr2', 'attr3'],
-                               issuerId='issuer1')
-    assert claimDef == ClaimDefinition.fromStrDict(claimDef.toStrDict())
+def testSchemaFromToDict():
+    schema = Schema(name='schemaName', version='1.0',
+                      schemaType='CL',
+                      attrNames=['attr1', 'attr2', 'attr3'],
+                      issuerId='issuer1')
+    assert schema == Schema.fromStrDict(schema.toStrDict())
 
 
 def testPKFromToDict():

--- a/anoncreds/test/test_util.py
+++ b/anoncreds/test/test_util.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+import pytest
+
 from anoncreds.protocol.globals import PAIRING_GROUP
 from anoncreds.protocol.utils import toDictWithStrValues, \
     deserializeFromStr, serializeToStr, fromDictWithStrValues, get_hash_as_int
@@ -27,11 +29,13 @@ def testCryptoIntModSerializeToFromStr():
     assert value == deserializeFromStr(serializeToStr(value))
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testGroupElementSerializeToFromStr():
     value = cmod.PairingGroup(PAIRING_GROUP).random(cmod.G1)
     assert value == deserializeFromStr(serializeToStr(value))
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testGroupElementZRIdentitySerializeToFromStr():
     elem = cmod.PairingGroup(PAIRING_GROUP).init(cmod.ZR, 555)
     identity = elem / elem
@@ -44,6 +48,7 @@ def testGroupElementG1IdentitySerializeToFromStr():
     assert identity == deserializeFromStr(serializeToStr(identity))
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testToFromDictWithStrValues():
     group = cmod.PairingGroup(PAIRING_GROUP)
     dictionary = OrderedDict((
@@ -63,6 +68,7 @@ def testToFromDictWithStrValuesInteKeys():
     assert dictionary == fromDictWithStrValues(toDictWithStrValues(dictionary))
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testToFromDictWithStrValuesLists():
     group = cmod.PairingGroup(PAIRING_GROUP)
     dictionary = OrderedDict((
@@ -102,6 +108,7 @@ def testToFromDictWithStrValuesSubDicts():
     assert dictionary == fromDictWithStrValues(toDictWithStrValues(dictionary))
 
 
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-86')
 def testToFromDictWithStrValuesMixed():
     group = cmod.PairingGroup(PAIRING_GROUP)
     dictionary = OrderedDict((

--- a/docs/diagrams/anoncred_seq.puml
+++ b/docs/diagrams/anoncred_seq.puml
@@ -11,13 +11,13 @@ note over I, S #white
     <font color=red>red:</font> store locally
 endnote
 
-== Claim Definition setup ==
+== Schema setup ==
 
-note over I: Define **Claim definition** with attributes **m1, m2, ..., ml**
+note over I: Define **Schema** with attributes **m1, m2, ..., ml**
 
-I -[#green]> S: Store **Claim Definition**
+I -[#green]> S: Store **Schema**
 
-== Issuer Setup for each Claim Definition==
+== Issuer Setup for each Schema==
 
 note over I: **1.** Generate Primary Keys: **PK** and **SK**\n**2.** Generate Non-revocation Keys: **PKr** and **SKr**
 
@@ -35,7 +35,7 @@ I -[#green]> S: Store **PKaccum, accum**
 I -[#green]> S: Store **Tails**
 
 
-== Claim Issuance for a Claim Definition==
+== Claim Issuance for a Schema==
 
 
 note over P: Generate Master Secret **m1**
@@ -48,7 +48,7 @@ note over P: **P1.** generate U, vPrime, Ur and vrPrime with prover-generated va
 
 P -> P: Store **vPrime**, **vrPrime**
 
-P -[#black]> I: **P2.** Request Claim for the given Claim Def, U and Ur.
+P -[#black]> I: **P2.** Request Claim for the given Schema, U and Ur.
 
 note over I
     **I1.** Set attribute values **m3,...ml** and encode to 256 bits
@@ -81,7 +81,7 @@ end note
 P -> P: Store **c1,c2,m2**
 
 
-== Presentation for each Claim Definition ==
+== Presentation for each Schema ==
 
 note over P
     **P1.** Take nonce **n1** from a Verifier's link

--- a/docs/diagrams/anoncred_seq_api.puml
+++ b/docs/diagrams/anoncred_seq_api.puml
@@ -9,7 +9,7 @@ note over I: Attribute Repo
 
 autonumber
 
-I -> S: genClaimDef
+I -> S: genSchema
 
 I -> S: genKeys
 

--- a/docs/diagrams/anoncred_seq_sovrin.puml
+++ b/docs/diagrams/anoncred_seq_sovrin.puml
@@ -13,13 +13,13 @@ note over I, D #white
     <font color=red>red:</font> store locally
 endnote
 
-== Claim Definition setup ==
+== Schema setup ==
 
-note over I: Define Claim definition with attributes **m1, m2, ..., ml**
+note over I: Define Schema with attributes **m1, m2, ..., ml**
 
-I -[#green]> S: Submit **CLAIM_DEF** txn
+I -[#green]> S: Submit **SCHEMA** txn
 
-== Issuer Setup for each Claim Definition==
+== Issuer Setup for each Schema==
 
 note over I: **1.** Generate Primary Keys: **PK** and **SK**\n**2.** Generate Non-revocation Keys: **PKr** and **SKr**
 
@@ -37,7 +37,7 @@ I -[#green]> S: Submit Accumulator Definition: **REVOC_REG** txn
 I -[#blue]> D: Publish **Tails**
 
 
-== Claim Issuance for a Claim Definition==
+== Claim Issuance for a Schema==
 
 
 note over P: Generate Master Secret **m1**
@@ -50,7 +50,7 @@ note over P: **P1.** generate U, vPrime, Ur and vrPrime with prover-generated va
 
 P -> P: Store **vPrime**, **vrPrime**
 
-P -[#black]> I: **P2.** Request Claim for the given Claim Def, U and Ur.
+P -[#black]> I: **P2.** Request Claim for the given Schema, U and Ur.
 
 note over I
     **I1.** Set attribute values **m3,...ml** and encode to 256 bits
@@ -87,7 +87,7 @@ end note
 P -> P: Store **c1,c2,m2**
 
 
-== Presentation for each Claim Definition ==
+== Presentation for each Schema ==
 
 note over P
     **P1.** Take nonce **n1** from a Verifier's link

--- a/setup-charm.sh
+++ b/setup-charm.sh
@@ -59,3 +59,6 @@ if [ -f "requirements.txt" ]; then
   pip install -r requirements.txt
 fi
 
+# configure dynamic linker run-time bindings
+sudo ldconfig
+


### PR DESCRIPTION
* add pattern for hidden files to gitignore

* replace all claim defs by schema in primary_claim_issuer.py

* replace all claim defs by schema primary_proof_builder.py

* replace all claim defs by schema primary_proof_verifier.py

* rename classes and parameters defined in types.py related to claim defs to schema

* use 'schema' instead of 'claim def' in classes and parameters in issuer_wallet

* use 'schema' instead of 'claim def' in classes and parameters in wallet

* use 'schema' instead of 'claim def' in classes and parameters in prover_wallet

* use 'schema' instead of 'claim def' in classes and parameters in issuer

* use 'schema' instead of 'claim def' in classes and parameters in proover

* use 'schema' instead of 'claim def' in classes and parameters in verifier

* fix cred_def name - rename it to schema in proover

* use 'schema' instead of 'claim def' in attribuyes_repo

* use 'schema' instead of 'claim def' in public_repo

* use 'schema' instead of 'claim def' in public_repo

* use 'schema' instead of 'claim def' in non_revocation_claim_issuer

* use 'schema' instead of 'claim def' in non_revocation_proof_builder

* use 'schema' instead of 'claim def' in non_revocation_proof_verifier

* use 'schema' instead of 'claim def' in conftest

* use 'schema' instead of 'claim def' in test_anoncred_usage

* use 'schema' instead of 'claim def' in test_find_claims_for_input

* use 'schema' instead of 'claim def' in test_non_revocation

* use 'schema' instead of 'claim def' in test_non_revocation

* use 'schema' instead of 'claim def' in test_single_prover_single_issuer

* use 'schema' instead of 'claim def' in test_types

* use 'schema' instead of 'claim def' in primary_proof_verifier and primary_claim_issuer

* use 'schema' instead of 'claim def' in puml diagrams

* use 'schema' instead of 'claim def' in comments and string constants